### PR TITLE
Respect instant mix visibility on home screen

### DIFF
--- a/Shelv Mac/Views/DiscoverView.swift
+++ b/Shelv Mac/Views/DiscoverView.swift
@@ -7,6 +7,7 @@ struct DiscoverView: View {
     @ObservedObject var offlineMode = OfflineModeService.shared
     @ObservedObject var downloadStore = DownloadStore.shared
     @AppStorage("recapEnabled") private var recapEnabled = false
+    @AppStorage(PersonalizationPreferenceKey.showInstantMixActions) private var showInstantMixActions = true
     @State private var mixLoading: String?
     private let player = AudioPlayerService.shared
 
@@ -144,49 +145,51 @@ struct DiscoverView: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 32) {
 
-                VStack(alignment: .leading, spacing: 12) {
-                    Text(String(localized: "smart_mixes"))
-                        .font(.title2).bold()
-                    VStack(spacing: 10) {
-                        MixButton(
-                            title: String(localized: "mix_newest_tracks"),
-                            icon: "sparkles",
-                            color: .blue,
-                            isLoading: mixLoading == "newest"
-                        ) {
-                            mixLoading = "newest"
-                            await vm.playMixNewest()
-                            mixLoading = nil
-                        }
-                        MixButton(
-                            title: String(localized: "mix_most_played"),
-                            icon: "chart.bar.fill",
-                            color: .orange,
-                            isLoading: mixLoading == "frequent"
-                        ) {
-                            mixLoading = "frequent"
-                            await vm.playMixFrequent()
-                            mixLoading = nil
-                        }
-                        MixButton(
-                            title: String(localized: "mix_recently_played"),
-                            icon: "clock.fill",
-                            color: .green,
-                            isLoading: mixLoading == "recent"
-                        ) {
-                            mixLoading = "recent"
-                            await vm.playMixRecent()
-                            mixLoading = nil
-                        }
-                        MixButton(
-                            title: String(localized: "mix_shuffle_all"),
-                            icon: "shuffle",
-                            color: .purple,
-                            isLoading: mixLoading == "random"
-                        ) {
-                            mixLoading = "random"
-                            await vm.playMixRandom()
-                            mixLoading = nil
+                if showInstantMixActions {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text(String(localized: "smart_mixes"))
+                            .font(.title2).bold()
+                        VStack(spacing: 10) {
+                            MixButton(
+                                title: String(localized: "mix_newest_tracks"),
+                                icon: "sparkles",
+                                color: .blue,
+                                isLoading: mixLoading == "newest"
+                            ) {
+                                mixLoading = "newest"
+                                await vm.playMixNewest()
+                                mixLoading = nil
+                            }
+                            MixButton(
+                                title: String(localized: "mix_most_played"),
+                                icon: "chart.bar.fill",
+                                color: .orange,
+                                isLoading: mixLoading == "frequent"
+                            ) {
+                                mixLoading = "frequent"
+                                await vm.playMixFrequent()
+                                mixLoading = nil
+                            }
+                            MixButton(
+                                title: String(localized: "mix_recently_played"),
+                                icon: "clock.fill",
+                                color: .green,
+                                isLoading: mixLoading == "recent"
+                            ) {
+                                mixLoading = "recent"
+                                await vm.playMixRecent()
+                                mixLoading = nil
+                            }
+                            MixButton(
+                                title: String(localized: "mix_shuffle_all"),
+                                icon: "shuffle",
+                                color: .purple,
+                                isLoading: mixLoading == "random"
+                            ) {
+                                mixLoading = "random"
+                                await vm.playMixRandom()
+                                mixLoading = nil
+                            }
                         }
                     }
                 }

--- a/Shelv TV/Views/Discover/DiscoverView.swift
+++ b/Shelv TV/Views/Discover/DiscoverView.swift
@@ -5,6 +5,7 @@ struct DiscoverView: View {
     @AppStorage("mixUseDatabase") private var mixUseDatabase = false
     @AppStorage("themeColor") private var themeColor = "violet"
     @AppStorage("recapEnabled") private var recapEnabled = false
+    @AppStorage(PersonalizationPreferenceKey.showInstantMixActions) private var showInstantMixActions = true
     private let api = SubsonicAPIService.shared
     private let player = AudioPlayerService.shared
 
@@ -52,15 +53,17 @@ struct DiscoverView: View {
                     .padding(.horizontal, 50)
                     .focusSection()
 
-                    // Smart-Mixe als saubere Akzent-Liste über die volle Breite (wie iOS/Mac)
-                    VStack(spacing: 16) {
-                        MixPill(title: String(localized: "mix_newest_tracks"), icon: "sparkles", accent: accent) { await play(.newest) }
-                        MixPill(title: String(localized: "mix_frequently_played"), icon: "chart.bar.fill", accent: accent) { await play(.frequent) }
-                        MixPill(title: String(localized: "mix_recently_played"), icon: "clock.fill", accent: accent) { await play(.recent) }
-                        MixPill(title: String(localized: "mix_shuffle_all"), icon: "shuffle", accent: accent) { await play(.random) }
+                    if showInstantMixActions {
+                        // Smart-Mixe als saubere Akzent-Liste über die volle Breite (wie iOS/Mac)
+                        VStack(spacing: 16) {
+                            MixPill(title: String(localized: "mix_newest_tracks"), icon: "sparkles", accent: accent) { await play(.newest) }
+                            MixPill(title: String(localized: "mix_frequently_played"), icon: "chart.bar.fill", accent: accent) { await play(.frequent) }
+                            MixPill(title: String(localized: "mix_recently_played"), icon: "clock.fill", accent: accent) { await play(.recent) }
+                            MixPill(title: String(localized: "mix_shuffle_all"), icon: "shuffle", accent: accent) { await play(.random) }
+                        }
+                        .padding(.horizontal, 50)
+                        .focusSection()
                     }
-                    .padding(.horizontal, 50)
-                    .focusSection()
 
                     albumRow(String(localized: "recently_added"), newest)
                     albumRow(String(localized: "recently_played"), recent)

--- a/Shelv/CarPlay/CarPlayDiscoverController.swift
+++ b/Shelv/CarPlay/CarPlayDiscoverController.swift
@@ -43,13 +43,19 @@ final class CarPlayDiscoverController {
             .store(in: &cancellables)
 
         var lastThemeColor = UserDefaults.standard.string(forKey: "themeColor") ?? "violet"
+        var lastShowInstantMixActions = UserDefaults.standard.bool(forKey: PersonalizationPreferenceKey.showInstantMixActions)
         NotificationCenter.default.publisher(for: UserDefaults.didChangeNotification)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 guard let self else { return }
-                let current = UserDefaults.standard.string(forKey: "themeColor") ?? "violet"
-                guard current != lastThemeColor else { return }
-                lastThemeColor = current
+                let currentThemeColor = UserDefaults.standard.string(forKey: "themeColor") ?? "violet"
+                let currentShowInstantMixActions = UserDefaults.standard.bool(
+                    forKey: PersonalizationPreferenceKey.showInstantMixActions
+                )
+                guard currentThemeColor != lastThemeColor
+                    || currentShowInstantMixActions != lastShowInstantMixActions else { return }
+                lastThemeColor = currentThemeColor
+                lastShowInstantMixActions = currentShowInstantMixActions
                 if OfflineModeService.shared.isOffline {
                     self.showOffline()
                 } else {
@@ -163,13 +169,15 @@ final class CarPlayDiscoverController {
     private func buildSections(imageMap: [String: UIImage] = [:]) -> [CPListSection] {
         var sections: [CPListSection] = []
 
-        // Mixes — reine Textzeilen, sauber untereinander
-        sections.append(CPListSection(items: [
-            makeMixItem(String(localized: "mix_newest_tracks"),     type: "newest",   icon: "sparkles"),
-            makeMixItem(String(localized: "mix_frequently_played"), type: "frequent", icon: "chart.bar.fill"),
-            makeMixItem(String(localized: "mix_recently_played"),   type: "recent",   icon: "clock.fill"),
-            makeMixItem(String(localized: "mix_shuffle_all"),       type: "random",   icon: "shuffle"),
-        ], header: "Mixes", sectionIndexTitle: nil))
+        if UserDefaults.standard.bool(forKey: PersonalizationPreferenceKey.showInstantMixActions) {
+            // Mixes — reine Textzeilen, sauber untereinander
+            sections.append(CPListSection(items: [
+                makeMixItem(String(localized: "mix_newest_tracks"),     type: "newest",   icon: "sparkles"),
+                makeMixItem(String(localized: "mix_frequently_played"), type: "frequent", icon: "chart.bar.fill"),
+                makeMixItem(String(localized: "mix_recently_played"),   type: "recent",   icon: "clock.fill"),
+                makeMixItem(String(localized: "mix_shuffle_all"),       type: "random",   icon: "shuffle"),
+            ], header: "Mixes", sectionIndexTitle: nil))
+        }
 
         // 4 Kategorien als Cover-Rows, kein Section-Header
         let categories: [(String, [Album])] = [
@@ -369,17 +377,8 @@ final class CarPlayDiscoverController {
                     await MainActor.run {
                         AudioPlayerService.shared.playShuffled(songs: songs)
                         CarPlayNavigation.presentNowPlaying(on: self.interfaceController)
-                        let snap = self.rootTemplate.sections
-                        if !snap.isEmpty {
-                            var freshSections = snap
-                            freshSections[0] = CPListSection(items: [
-                                self.makeMixItem(String(localized: "mix_newest_tracks"),     type: "newest",   icon: "sparkles"),
-                                self.makeMixItem(String(localized: "mix_frequently_played"), type: "frequent", icon: "chart.bar.fill"),
-                                self.makeMixItem(String(localized: "mix_recently_played"),   type: "recent",   icon: "clock.fill"),
-                                self.makeMixItem(String(localized: "mix_shuffle_all"),       type: "random",   icon: "shuffle"),
-                            ], header: "Mixes", sectionIndexTitle: nil)
-                            self.rootTemplate.updateSections(freshSections)
-                        }
+                        self.rootTemplate.updateSections(self.buildSections())
+                        self.startCoverEnrichment()
                     }
                 } catch {
                     await MainActor.run { self?.presentMixError(title: title, message: error.localizedDescription) }

--- a/Shelv/Views/DiscoverView.swift
+++ b/Shelv/Views/DiscoverView.swift
@@ -10,6 +10,7 @@ struct DiscoverView: View {
     @AppStorage("recapEnabled") private var recapEnabled = false
     @AppStorage("mixUseDatabase") private var mixUseDatabase = false
     @AppStorage(PersonalizationPreferenceKey.showRadio) private var showRadio = true
+    @AppStorage(PersonalizationPreferenceKey.showInstantMixActions) private var showInstantMixActions = true
     private var accentColor: Color { AppTheme.color(for: themeColorName) }
 
     private var recapButtonVisible: Bool {
@@ -61,32 +62,34 @@ struct DiscoverView: View {
                         }
                         .padding(.top, 60)
                     } else {
-                        VStack(spacing: 12) {
-                            mixButton(
-                                title: String(localized: "mix_newest_tracks"),
-                                icon: "sparkles",
-                                key: "newest"
-                            ) { await loadMix(type: "newest") }
+                        if showInstantMixActions {
+                            VStack(spacing: 12) {
+                                mixButton(
+                                    title: String(localized: "mix_newest_tracks"),
+                                    icon: "sparkles",
+                                    key: "newest"
+                                ) { await loadMix(type: "newest") }
 
-                            mixButton(
-                                title: String(localized: "mix_frequently_played"),
-                                icon: "chart.bar.fill",
-                                key: "frequent"
-                            ) { await loadMix(type: "frequent") }
+                                mixButton(
+                                    title: String(localized: "mix_frequently_played"),
+                                    icon: "chart.bar.fill",
+                                    key: "frequent"
+                                ) { await loadMix(type: "frequent") }
 
-                            mixButton(
-                                title: String(localized: "mix_recently_played"),
-                                icon: "clock.fill",
-                                key: "recent"
-                            ) { await loadMix(type: "recent") }
+                                mixButton(
+                                    title: String(localized: "mix_recently_played"),
+                                    icon: "clock.fill",
+                                    key: "recent"
+                                ) { await loadMix(type: "recent") }
 
-                            mixButton(
-                                title: String(localized: "mix_shuffle_all"),
-                                icon: "shuffle",
-                                key: "random"
-                            ) { await loadMix(type: "random") }
+                                mixButton(
+                                    title: String(localized: "mix_shuffle_all"),
+                                    icon: "shuffle",
+                                    key: "random"
+                                ) { await loadMix(type: "random") }
+                            }
+                            .padding(.horizontal)
                         }
-                        .padding(.horizontal)
 
                         albumSection(
                             title: String(localized: "recently_added"),


### PR DESCRIPTION
This makes the home/discover mix buttons follow the existing “Show Instant Mix Actions” preference.

When instant mix actions are hidden, the smart mix buttons are now also hidden on all platfoms so they don’t take up home screen space for people who don’t use them.

Also refreshes the CarPlay discover sections when the preference changes so the UI updates without needing an app restart.