### PR TITLE
feat: seed Infinity Mode from the current song instead of pure random

### DIFF
--- a/Shelv Mac/Views/InfinityMixPanel.swift
+++ b/Shelv Mac/Views/InfinityMixPanel.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct InfinityMixPanel: View {
     @AppStorage("infinityMixAheadCount") private var infinityMixAheadCount = 1
+    @AppStorage("infinityMixSeededEnabled") private var infinityMixSeededEnabled = true
     @Environment(\.themeColor) private var themeColor
     private let infinityMixAheadOptions = Array(1...10)
 
@@ -17,6 +18,15 @@ struct InfinityMixPanel: View {
                 .onChange(of: infinityMixAheadCount) { _, _ in
                     AudioPlayerService.shared.refreshInfinityMixWindow()
                 }
+                Toggle(String(localized: "infinity_mix_seeded"), isOn: $infinityMixSeededEnabled)
+                    .tint(themeColor)
+                    .onChange(of: infinityMixSeededEnabled) { _, _ in
+                        AudioPlayerService.shared.refreshInfinityMixWindow()
+                    }
+            } footer: {
+                Text(String(localized: "infinity_mix_seeded_footer"))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
         }
         .formStyle(.grouped)

--- a/Shelv Mac/de.lproj/Localizable.strings
+++ b/Shelv Mac/de.lproj/Localizable.strings
@@ -474,6 +474,8 @@
 "infinity_mode" = "Endlos-Modus";
 "infinity_mix" = "Infinity Mix";
 "infinity_mix_ahead_count" = "Titel hinzufügen";
+"infinity_mix_seeded" = "Zum laufenden Titel passen";
+"infinity_mix_seeded_footer" = "Der Endlos-Modus hängt Titel an, die zum laufenden Song passen, plus ein paar Zufallstitel, damit der Mix in Bewegung bleibt. Ausgeschaltet kommen rein zufällige Titel aus der ganzen Bibliothek.";
 "instant_mix" = "Instant Mix";
 "no_instant_mix_available" = "Kein Instant Mix verfügbar";
 "show_instant_mix" = "Instant Mix anzeigen";

--- a/Shelv Mac/en.lproj/Localizable.strings
+++ b/Shelv Mac/en.lproj/Localizable.strings
@@ -474,6 +474,8 @@
 "infinity_mode" = "Infinity Mode";
 "infinity_mix" = "Infinity Mix";
 "infinity_mix_ahead_count" = "Songs to add";
+"infinity_mix_seeded" = "Match current song";
+"infinity_mix_seeded_footer" = "Infinity Mode continues with songs similar to what is playing, plus a few random picks so the mix keeps moving. Turn this off to add purely random songs from your whole library.";
 "instant_mix" = "Instant Mix";
 "no_instant_mix_available" = "No Instant Mix Available";
 "show_instant_mix" = "Show Instant Mix";

--- a/Shelv Mac/zh-Hans.lproj/Localizable.strings
+++ b/Shelv Mac/zh-Hans.lproj/Localizable.strings
@@ -474,6 +474,8 @@
 "infinity_mode" = "无限模式";
 "infinity_mix" = "无限混合";
 "infinity_mix_ahead_count" = "添加歌曲数";
+"infinity_mix_seeded" = "匹配当前歌曲";
+"infinity_mix_seeded_footer" = "无限模式会续接与当前播放曲目相似的歌曲，并混入少量随机曲目，让混合保持新鲜。关闭后将从整个音乐库中随机添加歌曲。";
 "instant_mix" = "即时混音";
 "no_instant_mix_available" = "没有可用的即时混音";
 "show_instant_mix" = "显示即时混音";

--- a/Shelv TV/Views/Settings/PlaybackSettingsView.swift
+++ b/Shelv TV/Views/Settings/PlaybackSettingsView.swift
@@ -11,6 +11,7 @@ struct PlaybackSettingsView: View {
     @AppStorage("transcodingWifiBitrate") private var streamBitrate = 256
     @AppStorage("queueSyncMode") private var queueSyncMode = "off"
     @AppStorage("infinityMixAheadCount") private var infinityMixAheadCount = 1
+    @AppStorage("infinityMixSeededEnabled") private var infinityMixSeededEnabled = true
     @AppStorage("autoFetchLyrics") private var autoFetchLyrics = true
     @AppStorage("includeNavidromeLyrics") private var includeNavidromeLyrics = true
     @AppStorage("useCustomLrcLibServer") private var useCustomLrcLibServer = false
@@ -152,6 +153,12 @@ struct PlaybackSettingsView: View {
                 ) { _ in
                     AudioPlayerService.shared.refreshInfinityMixWindow()
                 }
+                // Kein Fußnotentext: reiner Text ist auf tvOS nicht fokussierbar und stört die
+                // Navigation in der Liste.
+                Toggle(String(localized: "infinity_mix_seeded"), isOn: $infinityMixSeededEnabled)
+                    .onChange(of: infinityMixSeededEnabled) { _, _ in
+                        AudioPlayerService.shared.refreshInfinityMixWindow()
+                    }
             }
         }
         .toolbar(.hidden, for: .tabBar)

--- a/Shelv TV/de.lproj/Localizable.strings
+++ b/Shelv TV/de.lproj/Localizable.strings
@@ -453,6 +453,7 @@
 "infinity_mode" = "Endlos-Modus";
 "infinity_mix" = "Infinity Mix";
 "infinity_mix_ahead_count" = "Titel hinzufügen";
+"infinity_mix_seeded" = "Zum laufenden Titel passen";
 "instant_mix" = "Instant Mix";
 "no_instant_mix_available" = "Kein Instant Mix verfügbar";
 "show_instant_mix" = "Instant Mix anzeigen";

--- a/Shelv TV/en.lproj/Localizable.strings
+++ b/Shelv TV/en.lproj/Localizable.strings
@@ -453,6 +453,7 @@
 "infinity_mode" = "Infinity Mode";
 "infinity_mix" = "Infinity Mix";
 "infinity_mix_ahead_count" = "Songs to add";
+"infinity_mix_seeded" = "Match current song";
 "instant_mix" = "Instant Mix";
 "no_instant_mix_available" = "No Instant Mix Available";
 "show_instant_mix" = "Show Instant Mix";

--- a/Shelv TV/zh-Hans.lproj/Localizable.strings
+++ b/Shelv TV/zh-Hans.lproj/Localizable.strings
@@ -453,6 +453,7 @@
 "infinity_mode" = "无限模式";
 "infinity_mix" = "无限混合";
 "infinity_mix_ahead_count" = "添加歌曲数";
+"infinity_mix_seeded" = "匹配当前歌曲";
 "instant_mix" = "即时混音";
 "no_instant_mix_available" = "没有可用的即时混音";
 "show_instant_mix" = "显示即时混音";

--- a/Shelv.xcodeproj/project.pbxproj
+++ b/Shelv.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		BC1001212FFE000000000001 /* ShelvCore/Support/PersonalizationSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1001202FFE000000000001 /* ShelvCore/Support/PersonalizationSettings.swift */; };
 		BC1001222FFE000000000001 /* ShelvCore/Models/RadioStation.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1001232FFE000000000001 /* ShelvCore/Models/RadioStation.swift */; };
 		BC1001242FFE000000000001 /* ShelvCore/Services/InstantMixQueueBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1001252FFE000000000001 /* ShelvCore/Services/InstantMixQueueBuilder.swift */; };
+		BC1001602FFE000000000001 /* ShelvCore/Services/InfinityMixPoolBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1001612FFE000000000001 /* ShelvCore/Services/InfinityMixPoolBuilder.swift */; };
 		BC1001262FFE000000000001 /* ShelvCore/Models/SubsonicServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1001272FFE000000000001 /* ShelvCore/Models/SubsonicServer.swift */; };
 		BC1001282FFE000000000001 /* ShelvCore/Services/OfflineServerErrorPresentationPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1001292FFE000000000001 /* ShelvCore/Services/OfflineServerErrorPresentationPolicy.swift */; };
 		BC10012A2FFE000000000001 /* ShelvCore/Services/ConnectivityDebugLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC10012B2FFE000000000001 /* ShelvCore/Services/ConnectivityDebugLog.swift */; };
@@ -113,6 +114,7 @@
 		BC1001202FFE000000000001 /* ShelvCore/Support/PersonalizationSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Support/PersonalizationSettings.swift; sourceTree = "<group>"; };
 		BC1001232FFE000000000001 /* ShelvCore/Models/RadioStation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Models/RadioStation.swift; sourceTree = "<group>"; };
 		BC1001252FFE000000000001 /* ShelvCore/Services/InstantMixQueueBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/InstantMixQueueBuilder.swift; sourceTree = "<group>"; };
+		BC1001612FFE000000000001 /* ShelvCore/Services/InfinityMixPoolBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/InfinityMixPoolBuilder.swift; sourceTree = "<group>"; };
 		BC1001272FFE000000000001 /* ShelvCore/Models/SubsonicServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Models/SubsonicServer.swift; sourceTree = "<group>"; };
 		BC1001292FFE000000000001 /* ShelvCore/Services/OfflineServerErrorPresentationPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/OfflineServerErrorPresentationPolicy.swift; sourceTree = "<group>"; };
 		BC10012B2FFE000000000001 /* ShelvCore/Services/ConnectivityDebugLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/ConnectivityDebugLog.swift; sourceTree = "<group>"; };
@@ -290,6 +292,7 @@
 				BC1001392FFE000000000001 /* ShelvCore/Services/ScrobbleDeliveryCoordinator.swift */,
 				BC10011A2FFE000000000001 /* ShelvCore/Services/URL+QueryParam.swift */,
 				BC1001252FFE000000000001 /* ShelvCore/Services/InstantMixQueueBuilder.swift */,
+				BC1001612FFE000000000001 /* ShelvCore/Services/InfinityMixPoolBuilder.swift */,
 				BC10011B2FFE000000000001 /* ShelvCore/Utilities/PathSafe.swift */,
 				BC10013B2FFE000000000001 /* ShelvCore/Utilities/ShelvIntentSearchVocabulary.swift */,
 				BC10012F2FFE000000000001 /* ShelvCore/Services/DownloadDatabase.swift */,
@@ -638,6 +641,7 @@
 				BC1001382FFE000000000001 /* ShelvCore/Services/ScrobbleDeliveryCoordinator.swift in Sources */,
 				BC10010A2FFE000000000001 /* ShelvCore/Services/URL+QueryParam.swift in Sources */,
 				BC1001242FFE000000000001 /* ShelvCore/Services/InstantMixQueueBuilder.swift in Sources */,
+				BC1001602FFE000000000001 /* ShelvCore/Services/InfinityMixPoolBuilder.swift in Sources */,
 				BC10010B2FFE000000000001 /* ShelvCore/Utilities/PathSafe.swift in Sources */,
 				BC10013A2FFE000000000001 /* ShelvCore/Utilities/ShelvIntentSearchVocabulary.swift in Sources */,
 				BC10012E2FFE000000000001 /* ShelvCore/Services/DownloadDatabase.swift in Sources */,

--- a/Shelv/Views/Settings/PlaybackSettingsView.swift
+++ b/Shelv/Views/Settings/PlaybackSettingsView.swift
@@ -9,6 +9,7 @@ struct PlaybackSettingsView: View {
     @AppStorage("recapThreshold") private var recapThreshold = 30
     @AppStorage("queueSyncMode") private var queueSyncMode = "off"
     @AppStorage("infinityMixAheadCount") private var infinityMixAheadCount = 1
+    @AppStorage("infinityMixSeededEnabled") private var infinityMixSeededEnabled = true
     @AppStorage(AudioPlayerStateKey.savePlayerState) private var savePlayerState = true
     @State private var showAboutQueueSync = false
 
@@ -128,7 +129,7 @@ struct PlaybackSettingsView: View {
                 }
             }
 
-            Section(String(localized: "infinity_mix")) {
+            Section {
                 Picker(selection: $infinityMixAheadCount) {
                     ForEach(infinityMixAheadOptions, id: \.self) { count in
                         Text("\(count)").tag(count)
@@ -141,6 +142,19 @@ struct PlaybackSettingsView: View {
                 .onChange(of: infinityMixAheadCount) { _, _ in
                     AudioPlayerService.shared.refreshInfinityMixWindow()
                 }
+                Toggle(isOn: $infinityMixSeededEnabled) {
+                    Label { Text(String(localized: "infinity_mix_seeded")) } icon: {
+                        Image(systemName: "wand.and.stars").foregroundStyle(accentColor)
+                    }
+                }
+                .tint(accentColor)
+                .onChange(of: infinityMixSeededEnabled) { _, _ in
+                    AudioPlayerService.shared.refreshInfinityMixWindow()
+                }
+            } header: {
+                Text(String(localized: "infinity_mix"))
+            } footer: {
+                Text(String(localized: "infinity_mix_seeded_footer"))
             }
 
             Section(String(localized: "player_state")) {

--- a/Shelv/de.lproj/Localizable.strings
+++ b/Shelv/de.lproj/Localizable.strings
@@ -449,6 +449,8 @@
 "infinity_mode" = "Endlos-Modus";
 "infinity_mix" = "Infinity Mix";
 "infinity_mix_ahead_count" = "Titel hinzufügen";
+"infinity_mix_seeded" = "Zum laufenden Titel passen";
+"infinity_mix_seeded_footer" = "Der Endlos-Modus hängt Titel an, die zum laufenden Song passen, plus ein paar Zufallstitel, damit der Mix in Bewegung bleibt. Ausgeschaltet kommen rein zufällige Titel aus der ganzen Bibliothek.";
 "instant_mix" = "Instant Mix";
 "no_instant_mix_available" = "Kein Instant Mix verfügbar";
 "show_instant_mix" = "Instant Mix anzeigen";

--- a/Shelv/en.lproj/Localizable.strings
+++ b/Shelv/en.lproj/Localizable.strings
@@ -449,6 +449,8 @@
 "infinity_mode" = "Infinity Mode";
 "infinity_mix" = "Infinity Mix";
 "infinity_mix_ahead_count" = "Songs to add";
+"infinity_mix_seeded" = "Match current song";
+"infinity_mix_seeded_footer" = "Infinity Mode continues with songs similar to what is playing, plus a few random picks so the mix keeps moving. Turn this off to add purely random songs from your whole library.";
 "instant_mix" = "Instant Mix";
 "no_instant_mix_available" = "No Instant Mix Available";
 "show_instant_mix" = "Show Instant Mix";

--- a/Shelv/zh-Hans.lproj/Localizable.strings
+++ b/Shelv/zh-Hans.lproj/Localizable.strings
@@ -449,6 +449,8 @@
 "infinity_mode" = "无限模式";
 "infinity_mix" = "无限混合";
 "infinity_mix_ahead_count" = "添加歌曲数";
+"infinity_mix_seeded" = "匹配当前歌曲";
+"infinity_mix_seeded_footer" = "无限模式会续接与当前播放曲目相似的歌曲，并混入少量随机曲目，让混合保持新鲜。关闭后将从整个音乐库中随机添加歌曲。";
 "instant_mix" = "即时混音";
 "no_instant_mix_available" = "没有可用的即时混音";
 "show_instant_mix" = "显示即时混音";

--- a/ShelvCore/Services/AudioPlayerService.swift
+++ b/ShelvCore/Services/AudioPlayerService.swift
@@ -247,6 +247,7 @@ class AudioPlayerService: ObservableObject {
     @AppStorage("replayGainMode") private var replayGainMode = "track"
     @AppStorage("infinityModeEnabled") private var infinityModeEnabled = false
     @AppStorage("infinityMixAheadCount") private var infinityMixAheadCount = 1
+    @AppStorage("infinityMixSeededEnabled") private var infinityMixSeededEnabled = true
     private var gaplessPreloadTriggered = false
     private var gaplessPreloadSong: Song? = nil
     private var gaplessPreloadURL: URL? = nil
@@ -2668,6 +2669,10 @@ class AudioPlayerService: ObservableObject {
     // MARK: - Endlos-Modus (Radio)
 
     private var infinityPool: [Song] = []
+    /// Song, aus dem der aktuelle Pool gebaut wurde, nil bei einem rein zufälligen Pool.
+    private var infinityPoolSeedId: String?
+    /// Zuletzt vom Endlos-Modus eingereihte Titel, damit sich der Mix nicht im Kreis dreht.
+    private var infinityRecentSongIds: [String] = []
     private var infinityTopUpTask: Task<Void, Never>?
     /// IDs der Titel, die der Endlos-Modus automatisch vorausgelegt hat. Sobald der User selbst
     /// etwas einreiht (Add to Queue / Play Next), werden diese Songs wieder entfernt — der bewusst
@@ -2678,7 +2683,7 @@ class AudioPlayerService: ObservableObject {
         min(max(infinityMixAheadCount, 1), 10)
     }
 
-    /// Hält bei aktivem Endlos-Modus die gewählte Anzahl Zufallstitel bereit.
+    /// Hält bei aktivem Endlos-Modus die gewählte Anzahl Titel bereit.
     /// - `startIfIdle`: nur `true` beim manuellen Einschalten des Toggles — dann startet bei
     ///   nichts-läuft sofort ein Zufallstitel. Beim Songwechsel `false`, damit nach einem Stop
     ///   die Wiedergabe nicht ungewollt wieder anspringt.
@@ -2730,6 +2735,9 @@ class AudioPlayerService: ObservableObject {
     }
 
     func refreshInfinityMixWindow() {
+        // Der Pool hängt an den Einstellungen, nach einer Änderung also neu aufbauen.
+        infinityPool.removeAll()
+        infinityPoolSeedId = nil
         syncInfinityPendingSongIds()
         trimInfinityPendingSongs(to: clampedInfinityMixAheadCount)
         guard infinityModeEnabled else { return }
@@ -2750,6 +2758,7 @@ class AudioPlayerService: ObservableObject {
             userQueue.append(song)
         }
         infinityPendingSongIds.append(song.id)
+        infinityRecentSongIds = InfinityMixPoolBuilder.appendingHistory(infinityRecentSongIds, adding: [song.id])
         if save { saveState() }
         return true
     }
@@ -2813,6 +2822,7 @@ class AudioPlayerService: ObservableObject {
 
     @MainActor
     private func nextInfinitySong() async -> Song? {
+        discardInfinityPoolIfSeedChanged()
         if infinityPool.isEmpty { await refillInfinityPool() }
         while !infinityPool.isEmpty {
             let song = infinityPool.removeFirst()
@@ -2821,8 +2831,32 @@ class AudioPlayerService: ObservableObject {
         return nil
     }
 
+    /// Ein Pool gehört zu dem Titel, aus dem er gebaut wurde. Startet der Nutzer selbst etwas
+    /// anderes, wird er verworfen, sonst passt der Nachschub weiter zum vorherigen Titel.
+    private func discardInfinityPoolIfSeedChanged() {
+        guard infinityMixSeededEnabled, !infinityPool.isEmpty, infinityPoolSeedId != nil else { return }
+        guard let currentId = currentSong?.id else { return }
+        guard currentId != infinityPoolSeedId, !infinityRecentSongIds.contains(currentId) else { return }
+        infinityPool.removeAll()
+        infinityPoolSeedId = nil
+    }
+
     @MainActor
     private func refillInfinityPool() async {
+        // Erst versuchen, an den laufenden Titel anzuknüpfen. Ohne Seed, offline oder wenn der
+        // Server nichts Passendes kennt, bleibt es beim Zufall.
+        if infinityMixSeededEnabled,
+           !OfflineModeService.shared.isOffline,
+           let seed = currentSong,
+           !isRadioPlayback {
+            let seeded = await seededInfinityPool(for: seed)
+            if !seeded.isEmpty {
+                infinityPool = seeded
+                infinityPoolSeedId = seed.id
+                return
+            }
+        }
+        infinityPoolSeedId = nil
         // Online: bis zu 3 Versuche (mit kleinem Backoff), bevor auf Downloads ausgewichen wird.
         // Offline: gar nicht erst beim Server versuchen — direkt Downloads (dort ist garantiert was).
         if !OfflineModeService.shared.isOffline {
@@ -2847,6 +2881,48 @@ class AudioPlayerService: ObservableObject {
                 suffix: rec.fileExtension, bitRate: nil, replayGain: nil
             )
         }.shuffled()
+    }
+
+    /// Titel, die zum laufenden Song passen: erst ähnliche Songs, dann ähnliche Künstler, dann das
+    /// Genre. Ein Teil bleibt Zufall, sonst dreht sich der Endlos-Modus um einen einzigen Künstler.
+    @MainActor
+    private func seededInfinityPool(for seed: Song) async -> [Song] {
+        let api = SubsonicAPIService.shared
+        let target = InfinityMixPoolBuilder.poolSize
+        var similar: [Song] = []
+        var seen: Set<String> = [seed.id]
+
+        func collect(_ songs: [Song]?) {
+            guard let songs else { return }
+            for song in songs where seen.insert(song.id).inserted {
+                similar.append(song)
+            }
+        }
+
+        collect(try? await api.getSimilarSongs(id: seed.id, count: target * 2, retries: 1))
+        if similar.count < target, let artistId = seed.artistId, !artistId.isEmpty {
+            collect(try? await api.getSimilarSongs2(id: artistId, count: target * 2, retries: 1))
+        }
+        if similar.count < target, let genre = seed.genre, !genre.isEmpty {
+            collect(try? await api.getRandomSongs(size: target * 2, genre: genre, retries: 1))
+        }
+        guard !similar.isEmpty else { return [] }
+
+        let discovery = (try? await api.getRandomSongs(size: target, retries: 1)) ?? []
+        return InfinityMixPoolBuilder.pool(
+            similar: similar,
+            discovery: discovery,
+            excluding: infinityExcludedSongIds(seed: seed)
+        )
+    }
+
+    /// Alles, was gerade läuft, schon in der Queue steht oder eben erst lief, bleibt draußen.
+    private func infinityExcludedSongIds(seed: Song) -> Set<String> {
+        var excluded = Set(infinityRecentSongIds)
+        excluded.insert(seed.id)
+        if let currentId = currentSong?.id { excluded.insert(currentId) }
+        excluded.formUnion(upcomingSongs().map(\.id))
+        return excluded
     }
 
     func addToQueue(_ songs: [Song]) {

--- a/ShelvCore/Services/AudioPlayerService.swift
+++ b/ShelvCore/Services/AudioPlayerService.swift
@@ -2883,8 +2883,15 @@ class AudioPlayerService: ObservableObject {
         }.shuffled()
     }
 
-    /// Titel, die zum laufenden Song passen: erst ähnliche Songs, dann ähnliche Künstler, dann das
-    /// Genre. Ein Teil bleibt Zufall, sonst dreht sich der Endlos-Modus um einen einzigen Künstler.
+    /// Titel, die zum laufenden Song passen. Die Kaskade geht von eng nach weit und bricht ab,
+    /// sobald genug beisammen ist: ähnliche Songs, ähnliche Künstler, Genre, Top-Songs des
+    /// Künstlers. Das ist dieselbe Kette, die der Instant Mix benutzt.
+    ///
+    /// Gemessen an einer echten Bibliothek liefert `getSimilarSongs` je nach Titel 8 bis 20
+    /// Treffer, denn der Server kann nur zurückgeben, was auch vorhanden ist. Ein knappes
+    /// Ergebnis darf den Endlos-Modus nicht ausbremsen, deshalb füllt der Zufallstopf den Rest
+    /// des Pools auf. Ein Teil bleibt ohnehin Zufall, sonst dreht sich der Mix um einen
+    /// einzigen Künstler.
     @MainActor
     private func seededInfinityPool(for seed: Song) async -> [Song] {
         let api = SubsonicAPIService.shared
@@ -2906,20 +2913,27 @@ class AudioPlayerService: ObservableObject {
         if similar.count < target, let genre = seed.genre, !genre.isEmpty {
             collect(try? await api.getRandomSongs(size: target * 2, genre: genre, retries: 1))
         }
+        if similar.count < target, let artistName = seed.artist, !artistName.isEmpty {
+            collect(try? await api.getTopSongs(artistName: artistName, count: target, retries: 1))
+        }
         guard !similar.isEmpty else { return [] }
 
         let discovery = (try? await api.getRandomSongs(size: target, retries: 1)) ?? []
-        return InfinityMixPoolBuilder.pool(
+        let queued = infinityQueuedSongIds(seed: seed)
+        let pool = InfinityMixPoolBuilder.pool(
             similar: similar,
             discovery: discovery,
-            excluding: infinityExcludedSongIds(seed: seed)
+            excluding: queued.union(infinityRecentSongIds)
         )
+        guard pool.isEmpty else { return pool }
+        // Kleine Bibliothek: der Verlauf hat alles weggefiltert. Dann lieber eine Wiederholung
+        // als ein leerer Pool, sonst endet der Endlos-Modus beim Zufall.
+        return InfinityMixPoolBuilder.pool(similar: similar, discovery: discovery, excluding: queued)
     }
 
-    /// Alles, was gerade läuft, schon in der Queue steht oder eben erst lief, bleibt draußen.
-    private func infinityExcludedSongIds(seed: Song) -> Set<String> {
-        var excluded = Set(infinityRecentSongIds)
-        excluded.insert(seed.id)
+    /// Alles, was gerade läuft oder schon in der Queue steht, bleibt draußen.
+    private func infinityQueuedSongIds(seed: Song) -> Set<String> {
+        var excluded: Set<String> = [seed.id]
         if let currentId = currentSong?.id { excluded.insert(currentId) }
         excluded.formUnion(upcomingSongs().map(\.id))
         return excluded

--- a/ShelvCore/Services/InfinityMixPoolBuilder.swift
+++ b/ShelvCore/Services/InfinityMixPoolBuilder.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+/// Stellt den Nachschub des Endlos-Modus zusammen. Reine Logik ohne Netz und ohne Player-Zustand,
+/// damit die Mischung testbar bleibt.
+nonisolated enum InfinityMixPoolBuilder {
+    /// Titel pro Nachfüll-Durchlauf.
+    static let poolSize = 25
+    /// Jeder n-te Titel kommt aus dem Zufallstopf: ohne diesen Anteil bliebe der Mix bei einem
+    /// einzigen Künstler hängen, sobald der Server nur enge Treffer liefert.
+    static let discoveryStride = 4
+    /// So viele zuletzt eingereihte Titel merkt sich der Endlos-Modus, um Wiederholungen zu meiden.
+    static let historyLimit = 200
+
+    /// Mischt zum laufenden Song passende Titel mit einem Anteil Zufallstiteln.
+    /// - Parameters:
+    ///   - similar: Treffer zum Seed, in Server-Reihenfolge (Relevanz zuerst).
+    ///   - discovery: Zufallstitel aus der Bibliothek.
+    ///   - excluding: IDs, die nicht erneut vorkommen dürfen (laufender Song, Queue, Verlauf).
+    ///   - limit: Maximale Poolgröße.
+    static func pool(
+        similar: [Song],
+        discovery: [Song],
+        excluding excluded: Set<String> = [],
+        limit: Int = poolSize
+    ) -> [Song] {
+        guard limit > 0 else { return [] }
+        var seen = excluded
+        var similarQueue = similar
+        var discoveryQueue = discovery
+        var result: [Song] = []
+
+        func take(from queue: inout [Song]) -> Song? {
+            while !queue.isEmpty {
+                let song = queue.removeFirst()
+                guard seen.insert(song.id).inserted else { continue }
+                return song
+            }
+            return nil
+        }
+
+        while result.count < limit {
+            let position = result.count + 1
+            let wantsDiscovery = discoveryStride > 0 && position % discoveryStride == 0
+            let picked = wantsDiscovery
+                ? take(from: &discoveryQueue) ?? take(from: &similarQueue)
+                : take(from: &similarQueue) ?? take(from: &discoveryQueue)
+            guard let song = picked else { break }
+            result.append(song)
+        }
+        return result
+    }
+
+    /// Hängt neue IDs an den Verlauf und kappt ihn vorne, damit er nicht unbegrenzt wächst.
+    static func appendingHistory(_ history: [String], adding ids: [String], limit: Int = historyLimit) -> [String] {
+        guard limit > 0 else { return [] }
+        var seen = Set<String>()
+        var merged: [String] = []
+        for id in (history + ids).reversed() where seen.insert(id).inserted {
+            merged.append(id)
+            if merged.count == limit { break }
+        }
+        return merged.reversed()
+    }
+}

--- a/ShelvTests/InfinityMixPoolBuilderTests.swift
+++ b/ShelvTests/InfinityMixPoolBuilderTests.swift
@@ -38,6 +38,18 @@ final class InfinityMixPoolBuilderTests: XCTestCase {
         XCTAssertEqual(pool.map(\.id), ["only-similar", "random-1", "random-2"])
     }
 
+    func testShortSimilarListStillFillsThePoolFromDiscovery() {
+        let pool = InfinityMixPoolBuilder.pool(
+            similar: (1...8).map { song("similar-\($0)") },
+            discovery: (1...40).map { song("random-\($0)") },
+            limit: InfinityMixPoolBuilder.poolSize
+        )
+
+        XCTAssertEqual(pool.count, InfinityMixPoolBuilder.poolSize)
+        XCTAssertEqual(pool.filter { $0.id.hasPrefix("similar-") }.count, 8)
+        XCTAssertEqual(Set(pool.map(\.id)).count, pool.count)
+    }
+
     func testPoolStopsWhenBothSourcesAreExhausted() {
         let pool = InfinityMixPoolBuilder.pool(
             similar: [song("a")],

--- a/ShelvTests/InfinityMixPoolBuilderTests.swift
+++ b/ShelvTests/InfinityMixPoolBuilderTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+
+final class InfinityMixPoolBuilderTests: XCTestCase {
+    func testPoolKeepsSimilarSongsFirstAndMixesInDiscovery() {
+        let pool = InfinityMixPoolBuilder.pool(
+            similar: (1...8).map { song("similar-\($0)") },
+            discovery: (1...8).map { song("random-\($0)") },
+            limit: 8
+        )
+
+        XCTAssertEqual(
+            pool.map(\.id),
+            [
+                "similar-1", "similar-2", "similar-3", "random-1",
+                "similar-4", "similar-5", "similar-6", "random-2"
+            ]
+        )
+    }
+
+    func testPoolSkipsExcludedAndDuplicateSongs() {
+        let pool = InfinityMixPoolBuilder.pool(
+            similar: [song("a"), song("recent"), song("a"), song("b")],
+            discovery: [song("b"), song("c")],
+            excluding: ["recent"],
+            limit: 8
+        )
+
+        XCTAssertEqual(pool.map(\.id), ["a", "b", "c"])
+    }
+
+    func testPoolFallsBackToDiscoveryWhenNoSimilarSongsAreLeft() {
+        let pool = InfinityMixPoolBuilder.pool(
+            similar: [song("only-similar")],
+            discovery: [song("random-1"), song("random-2")],
+            limit: 3
+        )
+
+        XCTAssertEqual(pool.map(\.id), ["only-similar", "random-1", "random-2"])
+    }
+
+    func testPoolStopsWhenBothSourcesAreExhausted() {
+        let pool = InfinityMixPoolBuilder.pool(
+            similar: [song("a")],
+            discovery: [],
+            limit: 25
+        )
+
+        XCTAssertEqual(pool.map(\.id), ["a"])
+    }
+
+    func testPoolIsEmptyForNonPositiveLimit() {
+        XCTAssertTrue(
+            InfinityMixPoolBuilder.pool(similar: [song("a")], discovery: [song("b")], limit: 0).isEmpty
+        )
+    }
+
+    func testHistoryKeepsMostRecentIdsWithoutDuplicates() {
+        let history = InfinityMixPoolBuilder.appendingHistory(["a", "b", "c"], adding: ["d", "b"], limit: 3)
+
+        XCTAssertEqual(history, ["c", "d", "b"])
+    }
+
+    func testHistoryGrowsUntilTheLimitIsReached() {
+        let history = InfinityMixPoolBuilder.appendingHistory([], adding: ["a", "b"], limit: 5)
+
+        XCTAssertEqual(history, ["a", "b"])
+    }
+
+    private func song(_ id: String) -> Song {
+        Song(id: id, title: id)
+    }
+}


### PR DESCRIPTION
## What Infinity Mode does today

`refillInfinityPool()` calls `getRandomSongs(size: 25)` and shuffles the result. The queue never runs dry, but the next track has no relation to the one playing: put on a jazz album and the mode can follow it with death metal. Meanwhile the app already has a solid similarity chain in `InstantMixService` (`getSimilarSongs` → `getSimilarSongs2` → genre → `getTopSongs`) that Infinity Mode does not use at all.

## What this changes

Infinity Mode now builds its pool from the song that is playing, through the same cascade Instant Mix uses. Each step only runs if the previous ones did not reach the 25 track target:

1. `getSimilarSongs` on the current song id
2. `getSimilarSongs2` on its artist id
3. `getRandomSongs(genre:)` on its genre
4. `getTopSongs` on its artist name

Whatever the cascade cannot fill is completed from a plain `getRandomSongs` pool, so a thin similarity result never shortens the queue. This matters in practice: on a 7000 track Navidrome library with the Last.fm agent configured, `getSimilarSongs` returned 20 tracks for one seed and only 8 for another, simply because the server can only return artists you actually own. The mix has to stay endless in both cases.

Every fourth slot is reserved for a random track (`InfinityMixPoolBuilder.discoveryStride`) even when the cascade delivers plenty. Without that share, a server with a good similarity index locks the mix onto one artist and the mode stops being a discovery feature.

The pool belongs to the song it was built from. When the user starts something else, it is dropped and rebuilt from the new track, so the mix follows the listening session instead of the track that started it. Tracks queued by Infinity Mode are remembered (last 200 ids) and excluded, along with the current song and everything already upcoming. On a library small enough for that history to filter out every candidate, the pool is rebuilt without it: a repeat is better than falling back to pure random.

Pure random remains the behaviour when:

- the cascade comes back empty (server with no similarity data at all)
- offline mode, or the download fallback
- radio playback
- the new **Match current song** toggle is off

## Settings

New toggle in the Infinity Mix section (iOS, macOS, tvOS), default on, with strings for `en`, `de` and `zh-Hans`. Changing it clears the pool so it takes effect on the next top-up rather than after the next 25 tracks.

## Cost

One refill covers 25 tracks. In the common case it is 2 requests (`getSimilarSongs` plus one `getRandomSongs` for the discovery share) instead of 1, and at worst 5 when every widening step is needed. Refills only happen when Infinity Mode is actually appending, so an album or a playlist still costs nothing.

## Tests

`ShelvTests/InfinityMixPoolBuilderTests.swift` covers the interleaving order, exclusion and dedup, a short similarity list still filling the pool to 25, the fallback when one source runs out, and the history cap. The mixing logic lives in `InfinityMixPoolBuilder` precisely so it can be tested without a server.

Verified locally with Xcode 26.6:

- `xcodebuild test` on the iOS simulator: full suite green, including the 8 new tests
- `xcodebuild build` for the macOS target: succeeds
- tvOS was not compiled, the tvOS 26.5 platform is not installed on this machine. The tvOS change is a `Toggle` plus an `onChange` matching the patterns already used in `Shelv TV/Views/Settings`. I deliberately left the explanatory footer out of the tvOS row, since plain `Text` rows are not focusable there.

## Notes

Happy to split the toggle out, change the default, or drop the discovery share if you would rather keep the mix strictly close to the seed.
