### PR TITLE
feat: rework the artist page on iOS and macOS

### DIFF
--- a/Shelv Mac/Views/ArtistDetailView.swift
+++ b/Shelv Mac/Views/ArtistDetailView.swift
@@ -30,6 +30,7 @@ struct ArtistDetailView: View {
     @State private var shareURL: URL?
     @State private var shareErrorMessage: String?
     @State private var artistSongs: [Song]?
+    @State private var topSongsExpanded = false
     @State private var isLoadingSearchSongs = false
     @State private var loadedSongSearchSourceID: String?
 
@@ -64,6 +65,12 @@ struct ArtistDetailView: View {
                 directionRaw: directionRaw
             )
         )
+    }
+
+    private var visibleTopSongs: [Song] {
+        topSongsExpanded
+            ? vm.topSongs
+            : Array(vm.topSongs.prefix(ArtistTopSongsRanking.collapsedLimit))
     }
 
     private var filteredSongs: [Song] {
@@ -119,6 +126,10 @@ struct ArtistDetailView: View {
                         }
                         .padding(.horizontal, 24)
                         .padding(.top, 20)
+
+                        if searchQuery.isEmpty && !visibleTopSongs.isEmpty {
+                            topSongsSection
+                        }
 
                         if !vm.albums.isEmpty {
                             if searchQuery.isEmpty {
@@ -294,6 +305,43 @@ struct ArtistDetailView: View {
         } message: { message in
             Text(message)
         }
+    }
+
+    private var topSongsSection: some View {
+        SearchSection(title: String(localized: "top_songs")) {
+            ForEach(Array(visibleTopSongs.enumerated()), id: \.element.id) { index, song in
+                HStack(spacing: 8) {
+                    Text("\(index + 1)")
+                        .font(.subheadline)
+                        .monospacedDigit()
+                        .foregroundStyle(.secondary)
+                        .frame(width: 18, alignment: .trailing)
+                        .padding(.leading, 20)
+                    SearchSongRow(song: song) {
+                        appState.player.play(songs: visibleTopSongs, startIndex: index)
+                    } onPlayNext: {
+                        appState.player.addPlayNext(song)
+                    } onAddToQueue: {
+                        appState.player.addToQueue(song)
+                    }
+                }
+            }
+
+            if vm.topSongs.count > ArtistTopSongsRanking.collapsedLimit {
+                Button {
+                    withAnimation(.easeInOut(duration: 0.2)) { topSongsExpanded.toggle() }
+                } label: {
+                    Text(topSongsExpanded
+                         ? String(localized: "show_less")
+                         : String(localized: "show_more"))
+                        .font(.subheadline).bold()
+                }
+                .buttonStyle(.link)
+                .padding(.horizontal, 20)
+                .padding(.top, 6)
+            }
+        }
+        .padding(.bottom, 8)
     }
 
     private func shareArtist() {
@@ -534,6 +582,7 @@ class ArtistDetailViewModel: ObservableObject {
     @Published var artist: ArtistDetail?
     @Published var albums: [Album] = []
     @Published var biography: String?
+    @Published var topSongs: [Song] = []
     @Published var isLoading: Bool = false
     @Published var isLoadingSongs: Bool = false
     @Published var errorMessage: String?
@@ -562,6 +611,24 @@ class ArtistDetailViewModel: ObservableObject {
             if artist == nil { errorMessage = inlineMessage }
         }
         isLoading = false
+        await loadTopSongs()
+    }
+
+    /// Loaded after the albums are on screen: the ranking is a bonus section,
+    /// it must never delay the page itself.
+    private func loadTopSongs() async {
+        guard !OfflineModeService.shared.isOffline else {
+            topSongs = []
+            return
+        }
+        let songs = await ArtistTopSongsService.topSongs(
+            artistName: artist?.name ?? "",
+            albums: albums
+        ) { albumID in
+            (try? await SubsonicAPIService.shared.getAlbum(id: albumID).song) ?? []
+        }
+        guard !Task.isCancelled else { return }
+        topSongs = songs
     }
 
     private func populateFromLocal(artistId: String, artistName: String) {

--- a/Shelv Mac/Views/ArtistDetailView.swift
+++ b/Shelv Mac/Views/ArtistDetailView.swift
@@ -32,6 +32,7 @@ struct ArtistDetailView: View {
     @State private var artistSongs: [Song]?
     @State private var topSongsExpanded = false
     @State private var releaseGroup: ArtistReleaseGroup = .all
+    @State private var externalStats: ArtistExternalStats = .none
     @State private var isLoadingSearchSongs = false
     @State private var loadedSongSearchSourceID: String?
 
@@ -75,6 +76,63 @@ struct ArtistDetailView: View {
         searchQuery.isEmpty ? ArtistDiscography.availableGroups(for: availableAlbums) : []
     }
 
+    private var albumsOnly: [Album] {
+        ArtistDiscography.filter(displayAlbums, to: .albums)
+    }
+
+    private var shortReleases: [Album] {
+        ArtistDiscography.filter(displayAlbums, to: .singlesAndEPs)
+    }
+
+    private var latestRelease: Album? {
+        availableAlbums.max {
+            ($0.year ?? 0, $0.created ?? .distantPast) < ($1.year ?? 0, $1.created ?? .distantPast)
+        }
+    }
+
+    private var showsBanner: Bool {
+        !(vm.artist?.coverArt ?? "").isEmpty
+    }
+
+    /// Releases and plays, from data the page already has. A discography holds
+    /// albums, singles and EPs, so it counts releases.
+    private var artistSubtitle: String? {
+        let albums = vm.albums
+        let count = vm.artist?.albumCount ?? albums.count
+        var parts: [String] = []
+        if count > 0 {
+            parts.append(String(format: String(localized: "artist_release_count_format"), count))
+        }
+        let plays = albums.reduce(0) { $0 + ($1.playCount ?? 0) }
+        if plays > 0 {
+            parts.append(String(format: String(localized: "artist_play_count_format"), plays))
+        }
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
+    }
+
+    private var artistFootnote: String? {
+        var parts: [String] = []
+        if let listeners = externalStats.listeners {
+            parts.append(String(
+                format: String(localized: "artist_lastfm_listeners_format"),
+                listeners.formatted(.number)
+            ))
+        }
+        if let rank = externalStats.worldRank {
+            parts.append(String(format: String(localized: "artist_world_rank_format"), rank))
+        }
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
+    }
+
+    private var lastFmURL: URL? {
+        vm.lastFmURLString.flatMap(URL.init(string:))
+    }
+
+    private var musicBrainzURL: URL? {
+        guard let id = vm.musicBrainzId, !id.isEmpty else { return nil }
+        return URL(string: "https://musicbrainz.org/artist/\(id)")
+    }
+
     private var visibleTopSongs: [Song] {
         topSongsExpanded
             ? vm.topSongs
@@ -109,6 +167,20 @@ struct ArtistDetailView: View {
             } else {
                 ScrollView {
                     VStack(alignment: .leading, spacing: 24) {
+                        if showsBanner {
+                            ArtistBannerHeader(
+                                coverArtID: vm.artist?.coverArt,
+                                name: vm.artist?.name ?? artistName,
+                                subtitle: artistSubtitle,
+                                footnote: artistFootnote
+                            ) {
+                                ViewThatFits(in: .horizontal) {
+                                    actionButtons(iconOnly: false, compact: false)
+                                    actionButtons(iconOnly: true, compact: false)
+                                    actionButtons(iconOnly: true, compact: true)
+                                }
+                            }
+                        } else {
                         HStack(alignment: .top, spacing: 24) {
                             CoverArtView(url: coverURL, size: 120, isCircle: true)
                                 .shadow(color: .black.opacity(0.2), radius: 10)
@@ -134,6 +206,7 @@ struct ArtistDetailView: View {
                         }
                         .padding(.horizontal, 24)
                         .padding(.top, 20)
+                        }
 
                         if searchQuery.isEmpty && !visibleTopSongs.isEmpty {
                             topSongsSection
@@ -192,20 +265,24 @@ struct ArtistDetailView: View {
                             }
 
                             if isGrid && searchQuery.isEmpty {
-                                LazyVGrid(
-                                    columns: [GridItem(.adaptive(minimum: 160, maximum: 200), spacing: 16)],
-                                    spacing: 20
-                                ) {
-                                    ForEach(displayAlbums) { album in
-                                        NavigationLink(value: album) {
-                                            AlbumGridItem(album: album)
-                                                .equatable()
-                                        }
-                                        .buttonStyle(.plain)
-                                        .albumContextMenu(album)
+                                VStack(alignment: .leading, spacing: 24) {
+                                    if let latestRelease {
+                                        ArtistLatestReleaseCard(album: latestRelease, accentColor: themeColor)
+                                    }
+                                    if !albumsOnly.isEmpty {
+                                        ArtistReleaseShelf(
+                                            title: String(localized: "albums"),
+                                            albums: albumsOnly
+                                        )
+                                    }
+                                    if !shortReleases.isEmpty {
+                                        ArtistReleaseShelf(
+                                            title: String(localized: "release_group_singles_eps"),
+                                            albums: shortReleases
+                                        )
                                     }
                                 }
-                                .padding(20)
+                                .padding(.bottom, 8)
                             } else if searchQuery.isEmpty {
                                 LazyVStack(spacing: 0) {
                                     ForEach(displayAlbums) { album in
@@ -271,6 +348,7 @@ struct ArtistDetailView: View {
                                     .font(.title3.bold())
                                 ArtistBiographyBox(biography: bio)
                                     .frame(maxWidth: 640)
+                                ArtistLinksRow(lastFmURL: lastFmURL, musicBrainzURL: musicBrainzURL)
                             }
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .padding(.horizontal, 20)
@@ -306,6 +384,7 @@ struct ArtistDetailView: View {
         }
         .task(id: "\(artistId)|\(musicLibraries.revision)") {
             await vm.load(artistId: artistId, artistName: artistName)
+            await loadExternalStats()
         }
         .task(id: songSearchLoadID) {
             guard !searchQuery.isEmpty, !availableAlbums.isEmpty else {
@@ -410,6 +489,21 @@ struct ArtistDetailView: View {
             }
         }
         .padding(.bottom, 8)
+    }
+
+    /// Optional and last: nothing on this page depends on it, and it is the
+    /// only request that leaves the user's own server.
+    private func loadExternalStats() async {
+        guard !offlineMode.isOffline, ArtistExternalStatsSettings.isEnabled else {
+            externalStats = .none
+            return
+        }
+        let stats = await ArtistExternalStatsService.shared.stats(
+            artistName: vm.artist?.name ?? artistName,
+            musicBrainzId: vm.musicBrainzId
+        )
+        guard !Task.isCancelled else { return }
+        externalStats = stats
     }
 
     private func shareArtist() {
@@ -645,17 +739,6 @@ struct ArtistDetailView: View {
     }
 }
 
-extension ArtistReleaseGroup {
-    /// Localised in each UI target, the way the other sort and filter enums are.
-    var label: String {
-        switch self {
-        case .all: String(localized: "release_group_all")
-        case .albums: String(localized: "albums")
-        case .singlesAndEPs: String(localized: "release_group_singles_eps")
-        }
-    }
-}
-
 @MainActor
 class ArtistDetailViewModel: ObservableObject {
     @Published var artist: ArtistDetail?
@@ -663,6 +746,8 @@ class ArtistDetailViewModel: ObservableObject {
     @Published var biography: String?
     @Published var topSongs: [Song] = []
     @Published var similarArtists: [Artist] = []
+    @Published var musicBrainzId: String?
+    @Published var lastFmURLString: String?
     @Published var isLoading: Bool = false
     @Published var isLoadingSongs: Bool = false
     @Published var errorMessage: String?
@@ -691,6 +776,8 @@ class ArtistDetailViewModel: ObservableObject {
             let info = try? await artistInfo
             biography = info?.biography?.strippingHTML
             similarArtists = info?.similarArtist ?? []
+            musicBrainzId = info?.musicBrainzId
+            lastFmURLString = info?.lastFmUrl
         } catch {
             let inlineMessage = OfflineModeService.shared.inlineErrorMessage(for: error)
             populateFromLocal(artistId: artistId, artistName: artistName)

--- a/Shelv Mac/Views/ArtistDetailView.swift
+++ b/Shelv Mac/Views/ArtistDetailView.swift
@@ -31,6 +31,7 @@ struct ArtistDetailView: View {
     @State private var shareErrorMessage: String?
     @State private var artistSongs: [Song]?
     @State private var topSongsExpanded = false
+    @State private var releaseGroup: ArtistReleaseGroup = .all
     @State private var isLoadingSearchSongs = false
     @State private var loadedSongSearchSourceID: String?
 
@@ -55,9 +56,12 @@ struct ArtistDetailView: View {
     }
 
     private var displayAlbums: [Album] {
-        let filtered = searchQuery.isEmpty
+        let searched = searchQuery.isEmpty
             ? availableAlbums
             : availableAlbums.filter { $0.name.localizedCaseInsensitiveContains(searchQuery) }
+        let filtered = searchQuery.isEmpty
+            ? ArtistDiscography.filter(searched, to: releaseGroup)
+            : searched
         return ArtistAlbumPlaybackOrder.sorted(
             filtered,
             preference: ArtistAlbumSortPreference(
@@ -65,6 +69,10 @@ struct ArtistDetailView: View {
                 directionRaw: directionRaw
             )
         )
+    }
+
+    private var releaseGroups: [ArtistReleaseGroup] {
+        searchQuery.isEmpty ? ArtistDiscography.availableGroups(for: availableAlbums) : []
     }
 
     private var visibleTopSongs: [Song] {
@@ -133,6 +141,23 @@ struct ArtistDetailView: View {
 
                         if !vm.albums.isEmpty {
                             if searchQuery.isEmpty {
+                                HStack(spacing: 12) {
+                                    Text(String(localized: "discography"))
+                                        .font(.title3.bold())
+                                    if !releaseGroups.isEmpty {
+                                        Picker(String(localized: "discography"), selection: $releaseGroup) {
+                                            ForEach(releaseGroups, id: \.rawValue) { group in
+                                                Text(group.label).tag(group)
+                                            }
+                                        }
+                                        .pickerStyle(.segmented)
+                                        .labelsHidden()
+                                        .fixedSize()
+                                    }
+                                    Spacer()
+                                }
+                                .padding(.horizontal, 20)
+
                                 HStack(spacing: 8) {
                                     Picker(String(localized: "sort"), selection: $sortRaw) {
                                         ForEach(LibrarySortOption.allCases.filter {
@@ -236,11 +261,20 @@ struct ArtistDetailView: View {
                             }
                         }
 
+                        if searchQuery.isEmpty && !vm.similarArtists.isEmpty {
+                            similarArtistsSection
+                        }
+
                         if let bio = vm.biography, !bio.isEmpty {
-                            ArtistBiographyBox(biography: bio)
-                                .frame(maxWidth: 640)
-                                .padding(.horizontal, 20)
-                                .padding(.bottom, 24)
+                            VStack(alignment: .leading, spacing: 12) {
+                                Text(String(localized: "more_info"))
+                                    .font(.title3.bold())
+                                ArtistBiographyBox(biography: bio)
+                                    .frame(maxWidth: 640)
+                            }
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.horizontal, 20)
+                            .padding(.bottom, 24)
                         }
                     }
                 }
@@ -305,6 +339,40 @@ struct ArtistDetailView: View {
         } message: { message in
             Text(message)
         }
+    }
+
+    private var similarArtistsSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(String(localized: "fans_also_like"))
+                .font(.title3.bold())
+                .padding(.horizontal, 20)
+
+            ScrollView(.horizontal) {
+                HStack(alignment: .top, spacing: 16) {
+                    ForEach(vm.similarArtists) { artist in
+                        NavigationLink(value: artist) {
+                            VStack(spacing: 8) {
+                                CoverArtView(
+                                    coverArtID: artist.coverArt,
+                                    requestSize: 200,
+                                    size: 104,
+                                    isCircle: true
+                                )
+                                Text(artist.name)
+                                    .font(.callout)
+                                    .lineLimit(2)
+                                    .multilineTextAlignment(.center)
+                                    .frame(width: 104)
+                            }
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .padding(.horizontal, 20)
+            }
+            .scrollIndicators(.hidden)
+        }
+        .padding(.bottom, 8)
     }
 
     private var topSongsSection: some View {
@@ -577,12 +645,24 @@ struct ArtistDetailView: View {
     }
 }
 
+extension ArtistReleaseGroup {
+    /// Localised in each UI target, the way the other sort and filter enums are.
+    var label: String {
+        switch self {
+        case .all: String(localized: "release_group_all")
+        case .albums: String(localized: "albums")
+        case .singlesAndEPs: String(localized: "release_group_singles_eps")
+        }
+    }
+}
+
 @MainActor
 class ArtistDetailViewModel: ObservableObject {
     @Published var artist: ArtistDetail?
     @Published var albums: [Album] = []
     @Published var biography: String?
     @Published var topSongs: [Song] = []
+    @Published var similarArtists: [Artist] = []
     @Published var isLoading: Bool = false
     @Published var isLoadingSongs: Bool = false
     @Published var errorMessage: String?
@@ -595,16 +675,22 @@ class ArtistDetailViewModel: ObservableObject {
         errorMessage = nil
         if OfflineModeService.shared.isOffline {
             populateFromLocal(artistId: artistId, artistName: artistName)
+            similarArtists = []
             isLoading = false
             return
         }
         do {
             async let artistDetail = api.getArtist(id: artistId)
-            async let artistInfo = api.getArtistInfo(id: artistId)
+            async let artistInfo = api.getArtistInfo(
+                id: artistId,
+                similarArtistCount: ArtistPageLayout.similarArtistCount
+            )
             let detail = try await artistDetail
             artist = detail
             albums = (detail.album ?? []).sorted { ($0.year ?? 0) > ($1.year ?? 0) }
-            biography = (try? await artistInfo)?.biography?.strippingHTML
+            let info = try? await artistInfo
+            biography = info?.biography?.strippingHTML
+            similarArtists = info?.similarArtist ?? []
         } catch {
             let inlineMessage = OfflineModeService.shared.inlineErrorMessage(for: error)
             populateFromLocal(artistId: artistId, artistName: artistName)

--- a/Shelv Mac/Views/ArtistPageSections.swift
+++ b/Shelv Mac/Views/ArtistPageSections.swift
@@ -1,0 +1,179 @@
+import SwiftUI
+
+extension ArtistReleaseGroup {
+    /// Localised in each UI target, the way the other sort and filter enums are.
+    var label: String {
+        switch self {
+        case .all: String(localized: "release_group_all")
+        case .albums: String(localized: "albums")
+        case .singlesAndEPs: String(localized: "release_group_singles_eps")
+        }
+    }
+}
+
+/// Full-width artist photo behind the name and the playback actions.
+///
+/// Servers hand out square artist images (Navidrome caps them at 1000 px), so
+/// the square is cropped to a band around its centre, where portraits keep the
+/// face. Artists without a photo keep the compact header instead.
+struct ArtistBannerHeader<Actions: View>: View {
+    let coverArtID: String?
+    let name: String
+    let subtitle: String?
+    let footnote: String?
+    @ViewBuilder let actions: Actions
+
+    private let height: CGFloat = 240
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            GeometryReader { geo in
+                CoverArtView(
+                    coverArtID: coverArtID,
+                    requestSize: 1000,
+                    size: geo.size.width,
+                    cornerRadius: 0
+                )
+                .frame(width: geo.size.width, height: geo.size.width)
+                .offset(y: -(geo.size.width - height) / 2)
+            }
+            .frame(height: height)
+            .clipped()
+            .overlay(alignment: .bottom) {
+                LinearGradient(
+                    colors: [.clear, Color(nsColor: .windowBackgroundColor)],
+                    startPoint: .center,
+                    endPoint: .bottom
+                )
+                .allowsHitTesting(false)
+            }
+            .overlay(alignment: .bottomLeading) {
+                HStack(alignment: .bottom, spacing: 16) {
+                    // The wide photo is often a group or a stage shot; the round
+                    // portrait is what identifies the artist at a glance.
+                    CoverArtView(coverArtID: coverArtID, requestSize: 300, size: 96, isCircle: true)
+                        .overlay(Circle().stroke(.background.opacity(0.6), lineWidth: 2))
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(name)
+                            .font(.largeTitle.bold())
+                            .lineLimit(2)
+                        if let subtitle {
+                            Text(subtitle)
+                                .foregroundStyle(.secondary)
+                        }
+                        if let footnote {
+                            Text(footnote)
+                                .font(.callout)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+                .padding(.horizontal, 24)
+                .padding(.bottom, 12)
+            }
+
+            actions
+                .padding(.horizontal, 24)
+        }
+    }
+}
+
+/// A horizontal shelf of releases. Splitting albums from singles reads better
+/// than one long grid with a filter on top of it.
+struct ArtistReleaseShelf: View {
+    let title: String
+    let albums: [Album]
+
+    private let itemWidth: CGFloat = 170
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(title)
+                .font(.title3.bold())
+                .padding(.horizontal, 24)
+
+            ScrollView(.horizontal) {
+                LazyHStack(alignment: .top, spacing: 16) {
+                    ForEach(albums) { album in
+                        NavigationLink(value: album) {
+                            AlbumGridItem(album: album)
+                                .equatable()
+                                .frame(width: itemWidth)
+                        }
+                        .buttonStyle(.plain)
+                        .albumContextMenu(album)
+                    }
+                }
+                .padding(.horizontal, 24)
+            }
+            .scrollIndicators(.hidden)
+        }
+    }
+}
+
+/// The artist's newest release, pulled out of the shelves so it is the first
+/// thing offered after the top songs.
+struct ArtistLatestReleaseCard: View {
+    let album: Album
+    let accentColor: Color
+
+    var body: some View {
+        NavigationLink(value: album) {
+            HStack(spacing: 16) {
+                CoverArtView(coverArtID: album.coverArt, requestSize: 300, size: 88)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(String(localized: "latest_release"))
+                        .font(.caption.bold())
+                        .foregroundStyle(accentColor)
+                    Text(album.name)
+                        .font(.headline)
+                        .lineLimit(2)
+                    if !album.displayYear.isEmpty {
+                        Text(album.displayYear)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                Spacer(minLength: 0)
+            }
+            .padding(12)
+            .frame(maxWidth: 520, alignment: .leading)
+            .background(.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 12))
+        }
+        .buttonStyle(.plain)
+        .padding(.horizontal, 24)
+    }
+}
+
+/// External pages for the artist, as chips under the biography.
+struct ArtistLinksRow: View {
+    let lastFmURL: URL?
+    let musicBrainzURL: URL?
+
+    var body: some View {
+        if lastFmURL != nil || musicBrainzURL != nil {
+            HStack(spacing: 10) {
+                if let lastFmURL {
+                    chip(String(localized: "last_fm"), url: lastFmURL)
+                }
+                if let musicBrainzURL {
+                    chip(String(localized: "musicbrainz"), url: musicBrainzURL)
+                }
+            }
+        }
+    }
+
+    private func chip(_ title: String, url: URL) -> some View {
+        Link(destination: url) {
+            HStack(spacing: 6) {
+                Image(systemName: "arrow.up.right").font(.caption2)
+                Text(title)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+            .background(.secondary.opacity(0.12), in: Capsule())
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/Shelv Mac/Views/UICustomizationsTab.swift
+++ b/Shelv Mac/Views/UICustomizationsTab.swift
@@ -150,6 +150,8 @@ private func localized(_ key: String) -> String {
 }
 
 private struct MacGeneralPersonalizationPanel: View {
+    @AppStorage(ArtistExternalStatsSettings.enabledKey) private var showExternalArtistStats = false
+    @AppStorage(ArtistExternalStatsSettings.lastFMKeyKey) private var lastFMAPIKey = ""
     @AppStorage(PersonalizationPreferenceKey.miniPlayerStyle) private var miniPlayerStyleRaw = PersonalizationMiniPlayerStyle.shelv.rawValue
     @AppStorage(PersonalizationPreferenceKey.showInstantMixActions) private var showInstantMixActions = true
     @AppStorage(PersonalizationPreferenceKey.showDiscoverInsights) private var showDiscoverInsights = true
@@ -169,6 +171,24 @@ private struct MacGeneralPersonalizationPanel: View {
                     Label(String(localized: "interface_style"), systemImage: "play.rectangle")
                 }
                 .pickerStyle(.segmented)
+            }
+
+            Section {
+                Toggle(isOn: $showExternalArtistStats) {
+                    Label(String(localized: "show_external_artist_stats"), systemImage: "chart.bar")
+                }
+                .tint(themeColor)
+
+                if showExternalArtistStats {
+                    SecureField(String(localized: "lastfm_api_key"), text: $lastFMAPIKey)
+                        .textFieldStyle(.roundedBorder)
+                }
+            } header: {
+                Text(String(localized: "artist_stats"))
+            } footer: {
+                Text(String(localized: "external_artist_stats_footer"))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
 
             Section {

--- a/Shelv Mac/de.lproj/Localizable.strings
+++ b/Shelv Mac/de.lproj/Localizable.strings
@@ -149,6 +149,9 @@
 "used" = "Belegt";
 "free_on_device" = "Frei auf Gerät";
 "songs" = "Titel";
+"top_songs" = "Top-Titel";
+"show_more" = "Mehr anzeigen";
+"show_less" = "Weniger anzeigen";
 "enable_downloads" = "Downloads aktivieren";
 "disable_downloads_2" = "Downloads deaktivieren?";
 "disabling_downloads_will_cancel_active_downloads_and_remove_downloads" = "Aktive Downloads werden abgebrochen und alle heruntergeladenen Songs, Alben und Künstler von diesem Gerät entfernt.";

--- a/Shelv Mac/de.lproj/Localizable.strings
+++ b/Shelv Mac/de.lproj/Localizable.strings
@@ -150,6 +150,17 @@
 "free_on_device" = "Frei auf Gerät";
 "songs" = "Titel";
 "top_songs" = "Top-Titel";
+"artist_play_count_format" = "%d Wiedergaben";
+"artist_release_count_format" = "%d Veröffentlichungen";
+"artist_lastfm_listeners_format" = "%@ Last.fm-Hörer";
+"artist_world_rank_format" = "#%d weltweit diesen Monat";
+"artist_stats" = "Künstler-Statistiken";
+"show_external_artist_stats" = "Öffentliche Zahlen anzeigen";
+"external_artist_stats_footer" = "Fragt Last.fm und ListenBrainz nach Hörerzahlen und der Chart-Position dieses Monats. Das ist die einzige Anfrage, die Shelv außerhalb deines eigenen Servers stellt. Last.fm braucht deinen eigenen API-Key.";
+"lastfm_api_key" = "Last.fm-API-Key";
+"latest_release" = "Neueste Veröffentlichung";
+"last_fm" = "Last.fm";
+"musicbrainz" = "MusicBrainz";
 "discography" = "Diskografie";
 "release_group_all" = "Alle";
 "release_group_singles_eps" = "Singles & EPs";

--- a/Shelv Mac/de.lproj/Localizable.strings
+++ b/Shelv Mac/de.lproj/Localizable.strings
@@ -150,6 +150,11 @@
 "free_on_device" = "Frei auf Gerät";
 "songs" = "Titel";
 "top_songs" = "Top-Titel";
+"discography" = "Diskografie";
+"release_group_all" = "Alle";
+"release_group_singles_eps" = "Singles & EPs";
+"fans_also_like" = "Fans mögen auch";
+"more_info" = "Mehr Infos";
 "show_more" = "Mehr anzeigen";
 "show_less" = "Weniger anzeigen";
 "enable_downloads" = "Downloads aktivieren";

--- a/Shelv Mac/en.lproj/Localizable.strings
+++ b/Shelv Mac/en.lproj/Localizable.strings
@@ -150,6 +150,11 @@
 "free_on_device" = "Free on device";
 "songs" = "Songs";
 "top_songs" = "Top Songs";
+"discography" = "Discography";
+"release_group_all" = "All";
+"release_group_singles_eps" = "Singles & EPs";
+"fans_also_like" = "Fans Also Like";
+"more_info" = "More Info";
 "show_more" = "Show more";
 "show_less" = "Show less";
 "enable_downloads" = "Enable Downloads";

--- a/Shelv Mac/en.lproj/Localizable.strings
+++ b/Shelv Mac/en.lproj/Localizable.strings
@@ -150,6 +150,17 @@
 "free_on_device" = "Free on device";
 "songs" = "Songs";
 "top_songs" = "Top Songs";
+"artist_play_count_format" = "%d plays";
+"artist_release_count_format" = "%d releases";
+"artist_lastfm_listeners_format" = "%@ Last.fm listeners";
+"artist_world_rank_format" = "#%d worldwide this month";
+"artist_stats" = "Artist Stats";
+"show_external_artist_stats" = "Show Public Figures";
+"external_artist_stats_footer" = "Asks Last.fm and ListenBrainz for listener counts and this month's chart position. This is the only request Shelv sends outside your own server. Last.fm needs your own API key.";
+"lastfm_api_key" = "Last.fm API Key";
+"latest_release" = "Latest Release";
+"last_fm" = "Last.fm";
+"musicbrainz" = "MusicBrainz";
 "discography" = "Discography";
 "release_group_all" = "All";
 "release_group_singles_eps" = "Singles & EPs";

--- a/Shelv Mac/en.lproj/Localizable.strings
+++ b/Shelv Mac/en.lproj/Localizable.strings
@@ -149,6 +149,9 @@
 "used" = "Used";
 "free_on_device" = "Free on device";
 "songs" = "Songs";
+"top_songs" = "Top Songs";
+"show_more" = "Show more";
+"show_less" = "Show less";
 "enable_downloads" = "Enable Downloads";
 "disable_downloads_2" = "Disable downloads?";
 "disabling_downloads_will_cancel_active_downloads_and_remove_downloads" = "Active downloads will be canceled and all downloaded songs, albums and artists will be removed from this device.";

--- a/Shelv Mac/zh-Hans.lproj/Localizable.strings
+++ b/Shelv Mac/zh-Hans.lproj/Localizable.strings
@@ -150,6 +150,11 @@
 "free_on_device" = "设备可用";
 "songs" = "歌曲";
 "top_songs" = "热门歌曲";
+"discography" = "作品";
+"release_group_all" = "全部";
+"release_group_singles_eps" = "单曲和 EP";
+"fans_also_like" = "粉丝也喜欢";
+"more_info" = "更多信息";
 "show_more" = "显示更多";
 "show_less" = "收起";
 "enable_downloads" = "启用下载";

--- a/Shelv Mac/zh-Hans.lproj/Localizable.strings
+++ b/Shelv Mac/zh-Hans.lproj/Localizable.strings
@@ -150,6 +150,17 @@
 "free_on_device" = "设备可用";
 "songs" = "歌曲";
 "top_songs" = "热门歌曲";
+"artist_play_count_format" = "%d 次播放";
+"artist_release_count_format" = "%d 张作品";
+"artist_lastfm_listeners_format" = "%@ 位 Last.fm 听众";
+"artist_world_rank_format" = "本月全球第 %d 位";
+"artist_stats" = "艺人数据";
+"show_external_artist_stats" = "显示公开数据";
+"external_artist_stats_footer" = "向 Last.fm 和 ListenBrainz 查询听众数和本月榜单排名。这是 Shelv 唯一会发往你自己服务器之外的请求。Last.fm 需要你自己的 API 密钥。";
+"lastfm_api_key" = "Last.fm API 密钥";
+"latest_release" = "最新发行";
+"last_fm" = "Last.fm";
+"musicbrainz" = "MusicBrainz";
 "discography" = "作品";
 "release_group_all" = "全部";
 "release_group_singles_eps" = "单曲和 EP";

--- a/Shelv Mac/zh-Hans.lproj/Localizable.strings
+++ b/Shelv Mac/zh-Hans.lproj/Localizable.strings
@@ -149,6 +149,9 @@
 "used" = "已用";
 "free_on_device" = "设备可用";
 "songs" = "歌曲";
+"top_songs" = "热门歌曲";
+"show_more" = "显示更多";
+"show_less" = "收起";
 "enable_downloads" = "启用下载";
 "disable_downloads_2" = "停用下载？";
 "disabling_downloads_will_cancel_active_downloads_and_remove_downloads" = "正在进行的下载将被取消，所有已下载的歌曲、专辑和艺术家都将从本设备移除。";

--- a/Shelv.xcodeproj/project.pbxproj
+++ b/Shelv.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		4B666BEAD970D72DFCFF9C7E /* ShelvCore/Services/RadioStationChangeLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8C9F16F5098EE7158A393F2 /* ShelvCore/Services/RadioStationChangeLogic.swift */; };
 		54755D0F4F7624D1CB2AFAA0 /* ShelvCore/Services/RemoteStreamFailureRetryPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D76D0722C024A55F5646646B /* ShelvCore/Services/RemoteStreamFailureRetryPolicy.swift */; };
 		767C48F98385493A929D3CF5 /* ShelvCore/Services/PlaylistDuplicateChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7032627BABC540CC8752182E /* ShelvCore/Services/PlaylistDuplicateChecker.swift */; };
+		4C9CE80450C542811BFC06B9 /* ShelvCore/Services/ArtistTopSongsRanking.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2D3956FCB8E5BA0EA7B365B /* ShelvCore/Services/ArtistTopSongsRanking.swift */; };
 		A6370E2FCC02E636B1CE06BB /* ShelvCore/Services/PlayLogReconciliationLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EB765BFF905DC588F357EC2 /* ShelvCore/Services/PlayLogReconciliationLogic.swift */; };
 		BC10000C2FFE000000000001 /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = BC10000D2FFE000000000001 /* GRDB */; };
 		BC1001012FFE000000000001 /* ShelvCore/Models/Album.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1001112FFE000000000001 /* ShelvCore/Models/Album.swift */; };
@@ -96,6 +97,7 @@
 		1EB765BFF905DC588F357EC2 /* ShelvCore/Services/PlayLogReconciliationLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/PlayLogReconciliationLogic.swift; sourceTree = "<group>"; };
 		3481C1649E04481CA0F35E60 /* ShelvCore/Models/RecapPeriod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Models/RecapPeriod.swift; sourceTree = "<group>"; };
 		7032627BABC540CC8752182E /* ShelvCore/Services/PlaylistDuplicateChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/PlaylistDuplicateChecker.swift; sourceTree = "<group>"; };
+		F2D3956FCB8E5BA0EA7B365B /* ShelvCore/Services/ArtistTopSongsRanking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/ArtistTopSongsRanking.swift; sourceTree = "<group>"; };
 		BC1000012FFE000000000001 /* ShelvTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ShelvTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BC1001112FFE000000000001 /* ShelvCore/Models/Album.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Models/Album.swift; sourceTree = "<group>"; };
 		BC1001122FFE000000000001 /* ShelvCore/Models/Artist.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Models/Artist.swift; sourceTree = "<group>"; };
@@ -269,6 +271,7 @@
 				BC1001272FFE000000000001 /* ShelvCore/Models/SubsonicServer.swift */,
 				C8C9F16F5098EE7158A393F2 /* ShelvCore/Services/RadioStationChangeLogic.swift */,
 				7032627BABC540CC8752182E /* ShelvCore/Services/PlaylistDuplicateChecker.swift */,
+				F2D3956FCB8E5BA0EA7B365B /* ShelvCore/Services/ArtistTopSongsRanking.swift */,
 				DB776033CC96417A93CA66DB /* ShelvCore/Services/ConcurrencyLimiter.swift */,
 				BC10012D2FFE000000000001 /* ShelvCore/Models/DownloadModels.swift */,
 				BC10013D2FFE000000000001 /* ShelvCore/Models/ShortcutPlaybackModels.swift */,
@@ -616,6 +619,7 @@
 				BC1001262FFE000000000001 /* ShelvCore/Models/SubsonicServer.swift in Sources */,
 				4B666BEAD970D72DFCFF9C7E /* ShelvCore/Services/RadioStationChangeLogic.swift in Sources */,
 				767C48F98385493A929D3CF5 /* ShelvCore/Services/PlaylistDuplicateChecker.swift in Sources */,
+				4C9CE80450C542811BFC06B9 /* ShelvCore/Services/ArtistTopSongsRanking.swift in Sources */,
 				D65A40B16B924F709F912515 /* ShelvCore/Services/ConcurrencyLimiter.swift in Sources */,
 				BC10012C2FFE000000000001 /* ShelvCore/Models/DownloadModels.swift in Sources */,
 				BC10013C2FFE000000000001 /* ShelvCore/Models/ShortcutPlaybackModels.swift in Sources */,

--- a/Shelv.xcodeproj/project.pbxproj
+++ b/Shelv.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		4B666BEAD970D72DFCFF9C7E /* ShelvCore/Services/RadioStationChangeLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8C9F16F5098EE7158A393F2 /* ShelvCore/Services/RadioStationChangeLogic.swift */; };
 		54755D0F4F7624D1CB2AFAA0 /* ShelvCore/Services/RemoteStreamFailureRetryPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D76D0722C024A55F5646646B /* ShelvCore/Services/RemoteStreamFailureRetryPolicy.swift */; };
 		767C48F98385493A929D3CF5 /* ShelvCore/Services/PlaylistDuplicateChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7032627BABC540CC8752182E /* ShelvCore/Services/PlaylistDuplicateChecker.swift */; };
+		A3BC3F4796D89CE06D73AEBA /* ShelvCore/Services/ArtistDiscography.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFBB0EAEC930A6AA93845AF6 /* ShelvCore/Services/ArtistDiscography.swift */; };
 		4C9CE80450C542811BFC06B9 /* ShelvCore/Services/ArtistTopSongsRanking.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2D3956FCB8E5BA0EA7B365B /* ShelvCore/Services/ArtistTopSongsRanking.swift */; };
 		A6370E2FCC02E636B1CE06BB /* ShelvCore/Services/PlayLogReconciliationLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EB765BFF905DC588F357EC2 /* ShelvCore/Services/PlayLogReconciliationLogic.swift */; };
 		BC10000C2FFE000000000001 /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = BC10000D2FFE000000000001 /* GRDB */; };
@@ -97,6 +98,7 @@
 		1EB765BFF905DC588F357EC2 /* ShelvCore/Services/PlayLogReconciliationLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/PlayLogReconciliationLogic.swift; sourceTree = "<group>"; };
 		3481C1649E04481CA0F35E60 /* ShelvCore/Models/RecapPeriod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Models/RecapPeriod.swift; sourceTree = "<group>"; };
 		7032627BABC540CC8752182E /* ShelvCore/Services/PlaylistDuplicateChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/PlaylistDuplicateChecker.swift; sourceTree = "<group>"; };
+		FFBB0EAEC930A6AA93845AF6 /* ShelvCore/Services/ArtistDiscography.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/ArtistDiscography.swift; sourceTree = "<group>"; };
 		F2D3956FCB8E5BA0EA7B365B /* ShelvCore/Services/ArtistTopSongsRanking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/ArtistTopSongsRanking.swift; sourceTree = "<group>"; };
 		BC1000012FFE000000000001 /* ShelvTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ShelvTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BC1001112FFE000000000001 /* ShelvCore/Models/Album.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Models/Album.swift; sourceTree = "<group>"; };
@@ -271,6 +273,7 @@
 				BC1001272FFE000000000001 /* ShelvCore/Models/SubsonicServer.swift */,
 				C8C9F16F5098EE7158A393F2 /* ShelvCore/Services/RadioStationChangeLogic.swift */,
 				7032627BABC540CC8752182E /* ShelvCore/Services/PlaylistDuplicateChecker.swift */,
+				FFBB0EAEC930A6AA93845AF6 /* ShelvCore/Services/ArtistDiscography.swift */,
 				F2D3956FCB8E5BA0EA7B365B /* ShelvCore/Services/ArtistTopSongsRanking.swift */,
 				DB776033CC96417A93CA66DB /* ShelvCore/Services/ConcurrencyLimiter.swift */,
 				BC10012D2FFE000000000001 /* ShelvCore/Models/DownloadModels.swift */,
@@ -619,6 +622,7 @@
 				BC1001262FFE000000000001 /* ShelvCore/Models/SubsonicServer.swift in Sources */,
 				4B666BEAD970D72DFCFF9C7E /* ShelvCore/Services/RadioStationChangeLogic.swift in Sources */,
 				767C48F98385493A929D3CF5 /* ShelvCore/Services/PlaylistDuplicateChecker.swift in Sources */,
+				A3BC3F4796D89CE06D73AEBA /* ShelvCore/Services/ArtistDiscography.swift in Sources */,
 				4C9CE80450C542811BFC06B9 /* ShelvCore/Services/ArtistTopSongsRanking.swift in Sources */,
 				D65A40B16B924F709F912515 /* ShelvCore/Services/ConcurrencyLimiter.swift in Sources */,
 				BC10012C2FFE000000000001 /* ShelvCore/Models/DownloadModels.swift in Sources */,

--- a/Shelv/Views/Library/ArtistDetailView.swift
+++ b/Shelv/Views/Library/ArtistDetailView.swift
@@ -30,6 +30,8 @@ struct ArtistDetailView: View {
     @State private var currentToast: ShelveToast?
     @State private var searchQuery = ""
     @State private var artistSongs: [Song]?
+    @State private var topSongs: [Song] = []
+    @State private var topSongsExpanded = false
     @State private var isLoadingSearchSongs = false
     @State private var loadedSongSearchSourceID: String?
     @State private var albumToDeleteDownloads: Album?
@@ -79,6 +81,16 @@ struct ArtistDetailView: View {
 
     private var songSearchLoadID: String {
         "\(searchQuery.isEmpty ? "idle" : "searching")|\(songSearchSourceID)"
+    }
+
+    private var visibleTopSongs: [Song] {
+        topSongsExpanded
+            ? topSongs
+            : Array(topSongs.prefix(ArtistTopSongsRanking.collapsedLimit))
+    }
+
+    private var showsTopSongs: Bool {
+        searchQuery.isEmpty && !visibleTopSongs.isEmpty
     }
 
     private var sortedAlbums: [Album] {
@@ -246,10 +258,38 @@ struct ArtistDetailView: View {
         .padding(.top, 16)
     }
 
+    private var topSongsGridSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(String(localized: "top_songs"))
+                .font(.title3).bold()
+
+            LazyVStack(spacing: 0) {
+                ForEach(Array(visibleTopSongs.enumerated()), id: \.element.id) { index, song in
+                    Button {
+                        player.play(songs: visibleTopSongs, startIndex: index)
+                    } label: {
+                        ArtistTopSongRow(rank: index + 1, song: song)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+
+            if topSongs.count > ArtistTopSongsRanking.collapsedLimit {
+                ArtistTopSongsToggle(isExpanded: $topSongsExpanded, accentColor: accentColor)
+                    .padding(.top, 4)
+            }
+        }
+        .padding(.horizontal)
+    }
+
     private var gridBody: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 24) {
                 artistHeader
+
+                if showsTopSongs {
+                    topSongsGridSection
+                }
 
                 if isLoading {
                     ProgressView()
@@ -328,6 +368,35 @@ struct ArtistDetailView: View {
                         .listRowInsets(EdgeInsets())
                         .listRowBackground(Color.clear)
                         .listRowSeparator(.hidden)
+                }
+            }
+
+            if showsTopSongs {
+                Section {
+                    ForEach(Array(visibleTopSongs.enumerated()), id: \.element.id) { index, song in
+                        Button {
+                            player.play(songs: visibleTopSongs, startIndex: index)
+                        } label: {
+                            ArtistTopSongRow(rank: index + 1, song: song)
+                        }
+                        .buttonStyle(.plain)
+                        .listRowInsets(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
+                    }
+
+                    if topSongs.count > ArtistTopSongsRanking.collapsedLimit {
+                        ArtistTopSongsToggle(isExpanded: $topSongsExpanded, accentColor: accentColor)
+                            .listRowInsets(EdgeInsets(top: 4, leading: 16, bottom: 4, trailing: 16))
+                            .listRowSeparator(.hidden)
+                    }
+                } header: {
+                    HStack {
+                        Text(String(localized: "top_songs"))
+                            .font(.title3).bold()
+                            .textCase(nil)
+                            .foregroundStyle(.primary)
+                        Spacer()
+                    }
+                    .padding(.leading, 0)
                 }
             }
 
@@ -639,6 +708,7 @@ struct ArtistDetailView: View {
         populateFromLocal()
         isLoading = detail == nil
         guard !offlineMode.isOffline else {
+            topSongs = []
             isLoading = false
             return
         }
@@ -653,6 +723,25 @@ struct ArtistDetailView: View {
             }
         }
         isLoading = false
+        await loadTopSongs()
+    }
+
+    /// Loaded after the albums are on screen: the ranking is a bonus section,
+    /// it must never delay the page itself.
+    private func loadTopSongs() async {
+        guard !offlineMode.isOffline else {
+            topSongs = []
+            return
+        }
+        let songs = await ArtistTopSongsService.topSongs(
+            artistName: artist.name,
+            albums: sortedAlbums
+        ) { albumID in
+            (try? await SubsonicAPIService.shared.getAlbum(id: albumID).song) ?? []
+        }
+        guard !Task.isCancelled else { return }
+        topSongs = songs
+        topSongsExpanded = false
     }
 
     private func populateFromLocal() {

--- a/Shelv/Views/Library/ArtistDetailView.swift
+++ b/Shelv/Views/Library/ArtistDetailView.swift
@@ -32,6 +32,8 @@ struct ArtistDetailView: View {
     @State private var artistSongs: [Song]?
     @State private var topSongs: [Song] = []
     @State private var topSongsExpanded = false
+    @State private var similarArtists: [Artist] = []
+    @State private var releaseGroup: ArtistReleaseGroup = .all
     @State private var isLoadingSearchSongs = false
     @State private var loadedSongSearchSourceID: String?
     @State private var albumToDeleteDownloads: Album?
@@ -91,6 +93,21 @@ struct ArtistDetailView: View {
 
     private var showsTopSongs: Bool {
         searchQuery.isEmpty && !visibleTopSongs.isEmpty
+    }
+
+    private var releaseGroups: [ArtistReleaseGroup] {
+        searchQuery.isEmpty ? ArtistDiscography.availableGroups(for: sortedAlbums) : []
+    }
+
+    /// The albums actually shown: the search filter first, then the
+    /// album / singles filter of the discography section.
+    private var displayedAlbums: [Album] {
+        guard searchQuery.isEmpty else { return filteredAlbums }
+        return ArtistDiscography.filter(filteredAlbums, to: releaseGroup)
+    }
+
+    private var showsSimilarArtists: Bool {
+        searchQuery.isEmpty && !similarArtists.isEmpty
     }
 
     private var sortedAlbums: [Album] {
@@ -304,12 +321,18 @@ struct ArtistDetailView: View {
                         .padding(.top, 40)
                         .frame(maxWidth: .infinity)
                 } else if !filteredAlbums.isEmpty {
-                    Text(String(localized: "albums"))
-                        .font(.title3).bold()
-                        .padding(.horizontal)
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text(String(localized: searchQuery.isEmpty ? "discography" : "albums"))
+                            .font(.title3).bold()
+
+                        if !releaseGroups.isEmpty {
+                            ArtistReleaseGroupPicker(selection: $releaseGroup, groups: releaseGroups)
+                        }
+                    }
+                    .padding(.horizontal)
 
                     LazyVGrid(columns: columns, spacing: 20) {
-                        ForEach(filteredAlbums) { album in
+                        ForEach(displayedAlbums) { album in
                             NavigationLink(destination: AlbumDetailView(album: album)) {
                                 AlbumCardView(
                                     album: album,
@@ -349,9 +372,24 @@ struct ArtistDetailView: View {
                     }
                 }
 
+                if showsSimilarArtists {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text(String(localized: "fans_also_like"))
+                            .font(.title3).bold()
+                            .padding(.horizontal)
+
+                        ArtistSimilarArtistsRow(artists: similarArtists)
+                    }
+                }
+
                 if let bio = biography, !bio.isEmpty {
-                    ArtistBiographyBox(biography: bio, accentColor: accentColor)
-                        .padding(.horizontal)
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text(String(localized: "more_info"))
+                            .font(.title3).bold()
+
+                        ArtistBiographyBox(biography: bio, accentColor: accentColor)
+                    }
+                    .padding(.horizontal)
                 }
 
                 PlayerBottomSpacer()
@@ -421,7 +459,13 @@ struct ArtistDetailView: View {
                 }
             } else if !filteredAlbums.isEmpty {
                 Section {
-                    ForEach(filteredAlbums) { album in
+                    if !releaseGroups.isEmpty {
+                        ArtistReleaseGroupPicker(selection: $releaseGroup, groups: releaseGroups)
+                            .listRowInsets(EdgeInsets(top: 4, leading: 16, bottom: 8, trailing: 16))
+                            .listRowSeparator(.hidden)
+                    }
+
+                    ForEach(displayedAlbums) { album in
                         NavigationLink(destination: AlbumDetailView(album: album)) {
                             albumListRow(album)
                         }
@@ -451,7 +495,7 @@ struct ArtistDetailView: View {
                     }
                 } header: {
                     HStack {
-                        Text(String(localized: "albums"))
+                        Text(String(localized: searchQuery.isEmpty ? "discography" : "albums"))
                             .font(.title3).bold()
                             .textCase(nil)
                             .foregroundStyle(.primary)
@@ -483,12 +527,37 @@ struct ArtistDetailView: View {
                 }
             }
 
+            if showsSimilarArtists {
+                Section {
+                    ArtistSimilarArtistsRow(artists: similarArtists)
+                        .listRowInsets(EdgeInsets(top: 8, leading: 0, bottom: 0, trailing: 0))
+                        .listRowBackground(Color.clear)
+                        .listRowSeparator(.hidden)
+                } header: {
+                    HStack {
+                        Text(String(localized: "fans_also_like"))
+                            .font(.title3).bold()
+                            .textCase(nil)
+                            .foregroundStyle(.primary)
+                        Spacer()
+                    }
+                }
+            }
+
             if let bio = biography, !bio.isEmpty {
                 Section {
                     ArtistBiographyBox(biography: bio, accentColor: accentColor)
-                        .listRowInsets(EdgeInsets(top: 24, leading: 16, bottom: 0, trailing: 16))
+                        .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 0, trailing: 16))
                         .listRowBackground(Color.clear)
                         .listRowSeparator(.hidden)
+                } header: {
+                    HStack {
+                        Text(String(localized: "more_info"))
+                            .font(.title3).bold()
+                            .textCase(nil)
+                            .foregroundStyle(.primary)
+                        Spacer()
+                    }
                 }
             }
 
@@ -709,14 +778,20 @@ struct ArtistDetailView: View {
         isLoading = detail == nil
         guard !offlineMode.isOffline else {
             topSongs = []
+            similarArtists = []
             isLoading = false
             return
         }
         do {
             async let artistDetail = SubsonicAPIService.shared.getArtist(id: artist.id)
-            async let artistInfo = SubsonicAPIService.shared.getArtistInfo(id: artist.id)
+            async let artistInfo = SubsonicAPIService.shared.getArtistInfo(
+                id: artist.id,
+                similarArtistCount: ArtistPageLayout.similarArtistCount
+            )
             detail = try await artistDetail
-            biography = (try? await artistInfo)?.biography?.strippingHTML
+            let info = try? await artistInfo
+            biography = info?.biography?.strippingHTML
+            similarArtists = info?.similarArtist ?? []
         } catch {
             if detail == nil {
                 errorMessage = error.localizedDescription

--- a/Shelv/Views/Library/ArtistDetailView.swift
+++ b/Shelv/Views/Library/ArtistDetailView.swift
@@ -33,6 +33,8 @@ struct ArtistDetailView: View {
     @State private var topSongs: [Song] = []
     @State private var topSongsExpanded = false
     @State private var similarArtists: [Artist] = []
+    @State private var externalStats: ArtistExternalStats = .none
+    @State private var musicBrainzId: String?
     @State private var releaseGroup: ArtistReleaseGroup = .all
     @State private var isLoadingSearchSongs = false
     @State private var loadedSongSearchSourceID: String?
@@ -106,6 +108,42 @@ struct ArtistDetailView: View {
         return ArtistDiscography.filter(filteredAlbums, to: releaseGroup)
     }
 
+    /// Albums and play counts the server already reported, in place of the
+    /// monthly-listener line a commercial service would show here.
+    private var artistSubtitle: String? {
+        let albums = detail?.album ?? []
+        let albumCount = detail?.albumCount ?? artist.albumCount ?? albums.count
+        var parts: [String] = []
+        if albumCount > 0 {
+            parts.append(String(format: String(localized: "artist_release_count_format"), albumCount))
+        }
+        let plays = albums.reduce(0) { $0 + ($1.playCount ?? 0) }
+        if plays > 0 {
+            parts.append(String(format: String(localized: "artist_play_count_format"), plays))
+        }
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
+    }
+
+    /// Second line of the banner: public numbers, only when the user turned
+    /// them on and a service answered.
+    private var artistFootnote: String? {
+        var parts: [String] = []
+        if let listeners = externalStats.listeners {
+            parts.append(String(
+                format: String(localized: "artist_lastfm_listeners_format"),
+                listeners.formatted(.number)
+            ))
+        }
+        if let rank = externalStats.worldRank {
+            parts.append(String(format: String(localized: "artist_world_rank_format"), rank))
+        }
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
+    }
+
+    private var showsBanner: Bool {
+        !(artist.coverArt ?? "").isEmpty
+    }
+
     private var showsSimilarArtists: Bool {
         searchQuery.isEmpty && !similarArtists.isEmpty
     }
@@ -128,8 +166,9 @@ struct ArtistDetailView: View {
                 listBody
             }
         }
+
         .searchable(text: $searchQuery, prompt: String(localized: "search_albums_and_songs"))
-        .navigationTitle(artist.name)
+        .navigationTitle(showsBanner ? "" : artist.name)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             if showFavoriteActions && !offlineMode.isOffline {
@@ -211,7 +250,26 @@ struct ArtistDetailView: View {
         }
     }
 
+    @ViewBuilder
     private var artistHeader: some View {
+        if showsBanner {
+            ArtistBannerHeader(
+                artist: artist,
+                subtitle: artistSubtitle,
+                footnote: artistFootnote,
+                accentColor: accentColor
+            ) {
+                HStack(spacing: 14) {
+                    playButton
+                    shuffleButton
+                }
+            }
+        } else {
+            compactArtistHeader
+        }
+    }
+
+    private var compactArtistHeader: some View {
         VStack(alignment: .leading, spacing: 16) {
             HStack(spacing: 16) {
                 AlbumArtView(coverArtId: artist.coverArt, size: 300, isCircle: true)
@@ -225,47 +283,8 @@ struct ArtistDetailView: View {
                             .foregroundStyle(.secondary)
                     }
                     HStack(spacing: 14) {
-                        Button {
-                            let albums = sortedAlbums
-                            guard !albums.isEmpty else { return }
-                            Task {
-                                let songs = await fetchAllSongs(from: albums)
-                                guard !songs.isEmpty else { return }
-                                player.play(songs: songs, startIndex: 0)
-                            }
-                        } label: {
-                            Label(String(localized: "play"), systemImage: "play.fill")
-                                .labelStyle(.titleAndIcon)
-                                .font(.body).bold()
-                                .foregroundStyle(.white)
-                                .frame(maxWidth: .infinity)
-                                .padding(.vertical, 14)
-                                .background(accentColor)
-                                .clipShape(Capsule())
-                        }
-                        .buttonStyle(.plain)
-                        .disabled(isLoading)
-
-                        Button {
-                            let albums = sortedAlbums
-                            guard !albums.isEmpty else { return }
-                            Task {
-                                let songs = await fetchAllSongs(from: albums)
-                                guard !songs.isEmpty else { return }
-                                player.playShuffled(songs: songs)
-                            }
-                        } label: {
-                            Label(String(localized: "shuffle"), systemImage: "shuffle")
-                                .labelStyle(.titleAndIcon)
-                                .font(.body).bold()
-                                .foregroundStyle(accentColor)
-                                .frame(maxWidth: .infinity)
-                                .padding(.vertical, 14)
-                                .background(accentColor.opacity(0.15))
-                                .clipShape(Capsule())
-                        }
-                        .buttonStyle(.plain)
-                        .disabled(isLoading)
+                        playButton
+                        shuffleButton
                     }
                 }
             }
@@ -273,6 +292,52 @@ struct ArtistDetailView: View {
         }
         .padding(.horizontal)
         .padding(.top, 16)
+    }
+
+    private var playButton: some View {
+        Button {
+            let albums = sortedAlbums
+            guard !albums.isEmpty else { return }
+            Task {
+                let songs = await fetchAllSongs(from: albums)
+                guard !songs.isEmpty else { return }
+                player.play(songs: songs, startIndex: 0)
+            }
+        } label: {
+            Label(String(localized: "play"), systemImage: "play.fill")
+                .labelStyle(.titleAndIcon)
+                .font(.body).bold()
+                .foregroundStyle(.white)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 14)
+                .background(accentColor)
+                .clipShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .disabled(isLoading)
+    }
+
+    private var shuffleButton: some View {
+        Button {
+            let albums = sortedAlbums
+            guard !albums.isEmpty else { return }
+            Task {
+                let songs = await fetchAllSongs(from: albums)
+                guard !songs.isEmpty else { return }
+                player.playShuffled(songs: songs)
+            }
+        } label: {
+            Label(String(localized: "shuffle"), systemImage: "shuffle")
+                .labelStyle(.titleAndIcon)
+                .font(.body).bold()
+                .foregroundStyle(accentColor)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 14)
+                .background(accentColor.opacity(0.15))
+                .clipShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .disabled(isLoading)
     }
 
     private var topSongsGridSection: some View {
@@ -779,6 +844,7 @@ struct ArtistDetailView: View {
         guard !offlineMode.isOffline else {
             topSongs = []
             similarArtists = []
+            externalStats = .none
             isLoading = false
             return
         }
@@ -792,6 +858,7 @@ struct ArtistDetailView: View {
             let info = try? await artistInfo
             biography = info?.biography?.strippingHTML
             similarArtists = info?.similarArtist ?? []
+            musicBrainzId = info?.musicBrainzId
         } catch {
             if detail == nil {
                 errorMessage = error.localizedDescription
@@ -799,6 +866,22 @@ struct ArtistDetailView: View {
         }
         isLoading = false
         await loadTopSongs()
+        await loadExternalStats()
+    }
+
+    /// Optional and last: nothing on this page depends on it, and it is the
+    /// only request that leaves the user's own server.
+    private func loadExternalStats() async {
+        guard !offlineMode.isOffline, ArtistExternalStatsSettings.isEnabled else {
+            externalStats = .none
+            return
+        }
+        let stats = await ArtistExternalStatsService.shared.stats(
+            artistName: artist.name,
+            musicBrainzId: musicBrainzId
+        )
+        guard !Task.isCancelled else { return }
+        externalStats = stats
     }
 
     /// Loaded after the albums are on screen: the ranking is a bonus section,

--- a/Shelv/Views/Library/ArtistDetailView.swift
+++ b/Shelv/Views/Library/ArtistDetailView.swift
@@ -35,6 +35,7 @@ struct ArtistDetailView: View {
     @State private var similarArtists: [Artist] = []
     @State private var externalStats: ArtistExternalStats = .none
     @State private var musicBrainzId: String?
+    @State private var lastFmURLString: String?
     @State private var releaseGroup: ArtistReleaseGroup = .all
     @State private var isLoadingSearchSongs = false
     @State private var loadedSongSearchSourceID: String?
@@ -97,8 +98,34 @@ struct ArtistDetailView: View {
         searchQuery.isEmpty && !visibleTopSongs.isEmpty
     }
 
+    /// The list layout keeps a single list, so it keeps the filter. The grid
+    /// layout splits albums and short releases into their own shelves instead.
     private var releaseGroups: [ArtistReleaseGroup] {
         searchQuery.isEmpty ? ArtistDiscography.availableGroups(for: sortedAlbums) : []
+    }
+
+    private var albumsOnly: [Album] {
+        ArtistDiscography.filter(sortedAlbums, to: .albums)
+    }
+
+    private var shortReleases: [Album] {
+        ArtistDiscography.filter(sortedAlbums, to: .singlesAndEPs)
+    }
+
+    /// Newest by release year, then by the date the server first saw it.
+    private var latestRelease: Album? {
+        sortedAlbums.max {
+            ($0.year ?? 0, $0.created ?? .distantPast) < ($1.year ?? 0, $1.created ?? .distantPast)
+        }
+    }
+
+    private var lastFmURL: URL? {
+        lastFmURLString.flatMap(URL.init(string:))
+    }
+
+    private var musicBrainzURL: URL? {
+        guard let musicBrainzId, !musicBrainzId.isEmpty else { return nil }
+        return URL(string: "https://musicbrainz.org/artist/\(musicBrainzId)")
     }
 
     /// The albums actually shown: the search filter first, then the
@@ -385,19 +412,13 @@ struct ArtistDetailView: View {
                         .padding(.horizontal)
                         .padding(.top, 40)
                         .frame(maxWidth: .infinity)
-                } else if !filteredAlbums.isEmpty {
-                    VStack(alignment: .leading, spacing: 12) {
-                        Text(String(localized: searchQuery.isEmpty ? "discography" : "albums"))
-                            .font(.title3).bold()
-
-                        if !releaseGroups.isEmpty {
-                            ArtistReleaseGroupPicker(selection: $releaseGroup, groups: releaseGroups)
-                        }
-                    }
-                    .padding(.horizontal)
+                } else if !searchQuery.isEmpty {
+                    Text(String(localized: "albums"))
+                        .font(.title3).bold()
+                        .padding(.horizontal)
 
                     LazyVGrid(columns: columns, spacing: 20) {
-                        ForEach(displayedAlbums) { album in
+                        ForEach(filteredAlbums) { album in
                             NavigationLink(destination: AlbumDetailView(album: album)) {
                                 AlbumCardView(
                                     album: album,
@@ -411,6 +432,26 @@ struct ArtistDetailView: View {
                         }
                     }
                     .padding(.horizontal)
+                } else {
+                    if let latestRelease {
+                        ArtistLatestReleaseCard(album: latestRelease, accentColor: accentColor)
+                    }
+
+                    if !albumsOnly.isEmpty {
+                        ArtistReleaseShelf(
+                            title: String(localized: "albums"),
+                            albums: albumsOnly,
+                            personalization: personalization
+                        )
+                    }
+
+                    if !shortReleases.isEmpty {
+                        ArtistReleaseShelf(
+                            title: String(localized: "release_group_singles_eps"),
+                            albums: shortReleases,
+                            personalization: personalization
+                        )
+                    }
                 }
 
                 if !searchQuery.isEmpty {
@@ -453,6 +494,8 @@ struct ArtistDetailView: View {
                             .font(.title3).bold()
 
                         ArtistBiographyBox(biography: bio, accentColor: accentColor)
+
+                        ArtistLinksRow(lastFmURL: lastFmURL, musicBrainzURL: musicBrainzURL)
                     }
                     .padding(.horizontal)
                 }
@@ -859,6 +902,7 @@ struct ArtistDetailView: View {
             biography = info?.biography?.strippingHTML
             similarArtists = info?.similarArtist ?? []
             musicBrainzId = info?.musicBrainzId
+            lastFmURLString = info?.lastFmUrl
         } catch {
             if detail == nil {
                 errorMessage = error.localizedDescription

--- a/Shelv/Views/Library/ArtistPageSections.swift
+++ b/Shelv/Views/Library/ArtistPageSections.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+extension ArtistReleaseGroup {
+    /// Localised in each UI target, the way the other sort and filter enums are.
+    var label: String {
+        switch self {
+        case .all: String(localized: "release_group_all")
+        case .albums: String(localized: "albums")
+        case .singlesAndEPs: String(localized: "release_group_singles_eps")
+        }
+    }
+}
+
+/// Album / singles filter of the discography section. Only shown when the
+/// artist has both kinds of release.
+struct ArtistReleaseGroupPicker: View {
+    @Binding var selection: ArtistReleaseGroup
+    let groups: [ArtistReleaseGroup]
+
+    var body: some View {
+        Picker(String(localized: "discography"), selection: $selection) {
+            ForEach(groups, id: \.rawValue) { group in
+                Text(group.label).tag(group)
+            }
+        }
+        .pickerStyle(.segmented)
+        .labelsHidden()
+    }
+}
+
+/// Related artists, as the server reports them. Circular covers match the
+/// artist rows used everywhere else in the library.
+struct ArtistSimilarArtistsRow: View {
+    let artists: [Artist]
+
+    private let itemWidth: CGFloat = 104
+
+    var body: some View {
+        ScrollView(.horizontal) {
+            HStack(alignment: .top, spacing: 16) {
+                ForEach(artists) { artist in
+                    NavigationLink(destination: ArtistDetailView(artist: artist)) {
+                        VStack(spacing: 8) {
+                            AlbumArtView(coverArtId: artist.coverArt, size: 300, isCircle: true)
+                                .frame(width: itemWidth, height: itemWidth)
+                            Text(artist.name)
+                                .font(.subheadline)
+                                .foregroundStyle(.primary)
+                                .lineLimit(2)
+                                .multilineTextAlignment(.center)
+                                .frame(width: itemWidth)
+                        }
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.horizontal)
+        }
+        .scrollIndicators(.hidden)
+    }
+}

--- a/Shelv/Views/Library/ArtistPageSections.swift
+++ b/Shelv/Views/Library/ArtistPageSections.swift
@@ -93,20 +93,28 @@ struct ArtistBannerHeader<Actions: View>: View {
                 .allowsHitTesting(false)
             }
             .overlay(alignment: .bottomLeading) {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(artist.name)
-                        .font(.largeTitle).bold()
-                        .lineLimit(2)
-                        .minimumScaleFactor(0.7)
-                    if let subtitle {
-                        Text(subtitle)
-                            .font(.subheadline)
-                            .foregroundStyle(.secondary)
-                    }
-                    if let footnote {
-                        Text(footnote)
-                            .font(.footnote)
-                            .foregroundStyle(.secondary)
+                HStack(alignment: .bottom, spacing: 14) {
+                    // The wide photo is often a group or a stage shot; the round
+                    // portrait is what identifies the artist at a glance.
+                    AlbumArtView(coverArtId: artist.coverArt, size: 300, isCircle: true)
+                        .frame(width: 84, height: 84)
+                        .overlay(Circle().stroke(.background.opacity(0.6), lineWidth: 2))
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(artist.name)
+                            .font(.title).bold()
+                            .lineLimit(2)
+                            .minimumScaleFactor(0.7)
+                        if let subtitle {
+                            Text(subtitle)
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                        }
+                        if let footnote {
+                            Text(footnote)
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
+                        }
                     }
                 }
                 .padding(.horizontal)
@@ -116,5 +124,116 @@ struct ArtistBannerHeader<Actions: View>: View {
             actions
                 .padding(.horizontal)
         }
+    }
+}
+
+/// A horizontal shelf of releases, the way the rest of Discover presents
+/// albums. Splitting albums from singles reads better than one long grid with
+/// a filter on top of it.
+struct ArtistReleaseShelf: View {
+    let title: String
+    let albums: [Album]
+    let personalization: PersonalizationSwipeConfiguration
+
+    private let itemWidth: CGFloat = 150
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(title)
+                .font(.title3).bold()
+                .padding(.horizontal)
+
+            ScrollView(.horizontal) {
+                LazyHStack(alignment: .top, spacing: 16) {
+                    ForEach(albums) { album in
+                        NavigationLink(destination: AlbumDetailView(album: album)) {
+                            AlbumCardView(
+                                album: album,
+                                personalization: personalization,
+                                showArtist: false,
+                                showYear: true
+                            )
+                            .equatable()
+                            .frame(width: itemWidth)
+                        }
+                        .buttonStyle(.plain)
+                        .albumContextMenu(album, showPreview: false)
+                    }
+                }
+                .padding(.horizontal)
+            }
+            .scrollIndicators(.hidden)
+        }
+    }
+}
+
+/// The artist's newest release, pulled out of the shelves so it is the first
+/// thing offered after the top songs.
+struct ArtistLatestReleaseCard: View {
+    let album: Album
+    let accentColor: Color
+
+    var body: some View {
+        NavigationLink(destination: AlbumDetailView(album: album)) {
+            HStack(spacing: 16) {
+                AlbumArtView(coverArtId: album.coverArt, size: 300)
+                    .frame(width: 92, height: 92)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(String(localized: "latest_release"))
+                        .font(.caption).bold()
+                        .foregroundStyle(accentColor)
+                    Text(album.name)
+                        .font(.headline)
+                        .foregroundStyle(.primary)
+                        .lineLimit(2)
+                        .multilineTextAlignment(.leading)
+                    if !album.displayYear.isEmpty {
+                        Text(album.displayYear)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                Spacer(minLength: 0)
+            }
+            .padding(12)
+            .background(.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 12))
+        }
+        .buttonStyle(.plain)
+        .padding(.horizontal)
+    }
+}
+
+/// External pages for the artist, as chips under the biography.
+struct ArtistLinksRow: View {
+    let lastFmURL: URL?
+    let musicBrainzURL: URL?
+
+    var body: some View {
+        if lastFmURL != nil || musicBrainzURL != nil {
+            HStack(spacing: 10) {
+                if let lastFmURL {
+                    chip(String(localized: "last_fm"), url: lastFmURL)
+                }
+                if let musicBrainzURL {
+                    chip(String(localized: "musicbrainz"), url: musicBrainzURL)
+                }
+            }
+        }
+    }
+
+    private func chip(_ title: String, url: URL) -> some View {
+        Link(destination: url) {
+            HStack(spacing: 6) {
+                Image(systemName: "arrow.up.right")
+                    .font(.caption2)
+                Text(title)
+                    .font(.subheadline)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 7)
+            .background(.secondary.opacity(0.12), in: Capsule())
+        }
+        .buttonStyle(.plain)
     }
 }

--- a/Shelv/Views/Library/ArtistPageSections.swift
+++ b/Shelv/Views/Library/ArtistPageSections.swift
@@ -59,3 +59,62 @@ struct ArtistSimilarArtistsRow: View {
         .scrollIndicators(.hidden)
     }
 }
+
+/// Full-width artist photo behind the name and the playback actions.
+///
+/// Servers hand out square artist images (Navidrome caps them at 1000 px), so
+/// the square is cropped to a band around its centre, where portraits keep the
+/// face. Pages whose artist has no image keep the compact header instead.
+struct ArtistBannerHeader<Actions: View>: View {
+    let artist: Artist
+    let subtitle: String?
+    /// Public figures from outside the server, when the user asked for them.
+    let footnote: String?
+    let accentColor: Color
+    @ViewBuilder let actions: Actions
+
+    private let height: CGFloat = 260
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            GeometryReader { geo in
+                AlbumArtView(coverArtId: artist.coverArt, size: 1000, cornerRadius: 0)
+                    .frame(width: geo.size.width, height: geo.size.width)
+                    .offset(y: -(geo.size.width - height) / 2)
+            }
+            .frame(height: height)
+            .clipped()
+            .overlay(alignment: .bottomLeading) {
+                LinearGradient(
+                    colors: [.clear, Color(UIColor.systemBackground)],
+                    startPoint: .center,
+                    endPoint: .bottom
+                )
+                .allowsHitTesting(false)
+            }
+            .overlay(alignment: .bottomLeading) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(artist.name)
+                        .font(.largeTitle).bold()
+                        .lineLimit(2)
+                        .minimumScaleFactor(0.7)
+                    if let subtitle {
+                        Text(subtitle)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                    if let footnote {
+                        Text(footnote)
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .padding(.horizontal)
+                .padding(.bottom, 12)
+            }
+
+            actions
+                .padding(.horizontal)
+        }
+    }
+}

--- a/Shelv/Views/Library/ArtistTopSongsSection.swift
+++ b/Shelv/Views/Library/ArtistTopSongsSection.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+/// A ranked row of the artist top-songs section. The rank is what separates
+/// this list from every other track list in the app, so it stays visible
+/// instead of relying on position alone.
+struct ArtistTopSongRow: View {
+    let rank: Int
+    let song: Song
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Text("\(rank)")
+                .font(.subheadline)
+                .monospacedDigit()
+                .foregroundStyle(.secondary)
+                .frame(width: 18, alignment: .trailing)
+            LibraryStarredSongRow(song: song)
+        }
+        .contentShape(Rectangle())
+    }
+}
+
+/// Expands the top-songs section from the collapsed five rows to the full list.
+struct ArtistTopSongsToggle: View {
+    @Binding var isExpanded: Bool
+    let accentColor: Color
+
+    var body: some View {
+        Button {
+            withAnimation(.easeInOut(duration: 0.2)) { isExpanded.toggle() }
+        } label: {
+            Text(isExpanded
+                 ? String(localized: "show_less")
+                 : String(localized: "show_more"))
+                .font(.subheadline).bold()
+                .foregroundStyle(accentColor)
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/Shelv/Views/Settings/SettingsView.swift
+++ b/Shelv/Views/Settings/SettingsView.swift
@@ -8,6 +8,8 @@ private enum SettingsRoute: Hashable {
 }
 
 struct SettingsView: View {
+    @AppStorage(ArtistExternalStatsSettings.enabledKey) private var showExternalArtistStats = false
+    @AppStorage(ArtistExternalStatsSettings.lastFMKeyKey) private var lastFMAPIKey = ""
     @EnvironmentObject var serverStore: ServerStore
     @AppStorage("appAppearance") private var appAppearance = "system"
     @AppStorage("themeColor") private var themeColorName = "violet"
@@ -63,6 +65,30 @@ struct SettingsView: View {
                         }
                     }
                     .id(themeColorName)
+                }
+
+                Section {
+                    Toggle(isOn: $showExternalArtistStats) {
+                        Label { Text(String(localized: "show_external_artist_stats")) } icon: {
+                            Image(systemName: "chart.bar").foregroundStyle(accentColor)
+                        }
+                    }
+                    .tint(accentColor)
+
+                    if showExternalArtistStats {
+                        LabeledContent {
+                            SecureField(String(localized: "lastfm_api_key"), text: $lastFMAPIKey)
+                                .textInputAutocapitalization(.never)
+                                .autocorrectionDisabled()
+                                .multilineTextAlignment(.trailing)
+                        } label: {
+                            Text(String(localized: "lastfm_api_key"))
+                        }
+                    }
+                } header: {
+                    Text(String(localized: "artist_stats"))
+                } footer: {
+                    Text(String(localized: "external_artist_stats_footer"))
                 }
 
                 Section(String(localized: "recap")) {

--- a/Shelv/de.lproj/Localizable.strings
+++ b/Shelv/de.lproj/Localizable.strings
@@ -27,6 +27,15 @@
 "show_more" = "Mehr anzeigen";
 "show_less" = "Weniger anzeigen";
 "top_songs" = "Top-Titel";
+"artist_release_count_format" = "%d Veröffentlichungen";
+"artist_lastfm_listeners_format" = "%@ Last.fm-Hörer";
+"artist_world_rank_format" = "#%d weltweit diesen Monat";
+"artist_stats" = "Künstler-Statistiken";
+"show_external_artist_stats" = "Öffentliche Zahlen anzeigen";
+"external_artist_stats_footer" = "Fragt Last.fm und ListenBrainz nach Hörerzahlen und der Chart-Position dieses Monats. Das ist die einzige Anfrage, die Shelv außerhalb deines eigenen Servers stellt. Last.fm braucht deinen eigenen API-Key.";
+"lastfm_api_key" = "Last.fm-API-Key";
+"artist_play_count_format" = "%d Wiedergaben";
+"count_albums_format" = "%d Alben";
 "discography" = "Diskografie";
 "release_group_all" = "Alle";
 "release_group_singles_eps" = "Singles & EPs";

--- a/Shelv/de.lproj/Localizable.strings
+++ b/Shelv/de.lproj/Localizable.strings
@@ -27,6 +27,9 @@
 "show_more" = "Mehr anzeigen";
 "show_less" = "Weniger anzeigen";
 "top_songs" = "Top-Titel";
+"latest_release" = "Neueste Veröffentlichung";
+"last_fm" = "Last.fm";
+"musicbrainz" = "MusicBrainz";
 "artist_release_count_format" = "%d Veröffentlichungen";
 "artist_lastfm_listeners_format" = "%@ Last.fm-Hörer";
 "artist_world_rank_format" = "#%d weltweit diesen Monat";

--- a/Shelv/de.lproj/Localizable.strings
+++ b/Shelv/de.lproj/Localizable.strings
@@ -27,6 +27,11 @@
 "show_more" = "Mehr anzeigen";
 "show_less" = "Weniger anzeigen";
 "top_songs" = "Top-Titel";
+"discography" = "Diskografie";
+"release_group_all" = "Alle";
+"release_group_singles_eps" = "Singles & EPs";
+"fans_also_like" = "Fans mögen auch";
+"more_info" = "Mehr Infos";
 "downloads" = "Downloads";
 "library" = "Bibliothek";
 "libraries" = "Bibliotheken";

--- a/Shelv/de.lproj/Localizable.strings
+++ b/Shelv/de.lproj/Localizable.strings
@@ -25,6 +25,8 @@
 "track_collection_duration_hours_format" = "%d Std.";
 "track_collection_duration_hours_minutes_format" = "%d Std. %d Min.";
 "show_more" = "Mehr anzeigen";
+"show_less" = "Weniger anzeigen";
+"top_songs" = "Top-Titel";
 "downloads" = "Downloads";
 "library" = "Bibliothek";
 "libraries" = "Bibliotheken";

--- a/Shelv/en.lproj/Localizable.strings
+++ b/Shelv/en.lproj/Localizable.strings
@@ -25,6 +25,8 @@
 "track_collection_duration_hours_format" = "%d hr";
 "track_collection_duration_hours_minutes_format" = "%d hr %d min";
 "show_more" = "Show more";
+"show_less" = "Show less";
+"top_songs" = "Top Songs";
 "downloads" = "Downloads";
 "library" = "Library";
 "libraries" = "Libraries";

--- a/Shelv/en.lproj/Localizable.strings
+++ b/Shelv/en.lproj/Localizable.strings
@@ -27,6 +27,11 @@
 "show_more" = "Show more";
 "show_less" = "Show less";
 "top_songs" = "Top Songs";
+"discography" = "Discography";
+"release_group_all" = "All";
+"release_group_singles_eps" = "Singles & EPs";
+"fans_also_like" = "Fans Also Like";
+"more_info" = "More Info";
 "downloads" = "Downloads";
 "library" = "Library";
 "libraries" = "Libraries";

--- a/Shelv/en.lproj/Localizable.strings
+++ b/Shelv/en.lproj/Localizable.strings
@@ -27,6 +27,9 @@
 "show_more" = "Show more";
 "show_less" = "Show less";
 "top_songs" = "Top Songs";
+"latest_release" = "Latest Release";
+"last_fm" = "Last.fm";
+"musicbrainz" = "MusicBrainz";
 "artist_release_count_format" = "%d releases";
 "artist_lastfm_listeners_format" = "%@ Last.fm listeners";
 "artist_world_rank_format" = "#%d worldwide this month";

--- a/Shelv/en.lproj/Localizable.strings
+++ b/Shelv/en.lproj/Localizable.strings
@@ -27,6 +27,15 @@
 "show_more" = "Show more";
 "show_less" = "Show less";
 "top_songs" = "Top Songs";
+"artist_release_count_format" = "%d releases";
+"artist_lastfm_listeners_format" = "%@ Last.fm listeners";
+"artist_world_rank_format" = "#%d worldwide this month";
+"artist_stats" = "Artist Stats";
+"show_external_artist_stats" = "Show Public Figures";
+"external_artist_stats_footer" = "Asks Last.fm and ListenBrainz for listener counts and this month's chart position. This is the only request Shelv sends outside your own server. Last.fm needs your own API key.";
+"lastfm_api_key" = "Last.fm API Key";
+"artist_play_count_format" = "%d plays";
+"count_albums_format" = "%d Albums";
 "discography" = "Discography";
 "release_group_all" = "All";
 "release_group_singles_eps" = "Singles & EPs";

--- a/Shelv/zh-Hans.lproj/Localizable.strings
+++ b/Shelv/zh-Hans.lproj/Localizable.strings
@@ -27,6 +27,15 @@
 "show_more" = "显示更多";
 "show_less" = "收起";
 "top_songs" = "热门歌曲";
+"artist_release_count_format" = "%d 张作品";
+"artist_lastfm_listeners_format" = "%@ 位 Last.fm 听众";
+"artist_world_rank_format" = "本月全球第 %d 位";
+"artist_stats" = "艺人数据";
+"show_external_artist_stats" = "显示公开数据";
+"external_artist_stats_footer" = "向 Last.fm 和 ListenBrainz 查询听众数和本月榜单排名。这是 Shelv 唯一会发往你自己服务器之外的请求。Last.fm 需要你自己的 API 密钥。";
+"lastfm_api_key" = "Last.fm API 密钥";
+"artist_play_count_format" = "%d 次播放";
+"count_albums_format" = "%d 张专辑";
 "discography" = "作品";
 "release_group_all" = "全部";
 "release_group_singles_eps" = "单曲和 EP";

--- a/Shelv/zh-Hans.lproj/Localizable.strings
+++ b/Shelv/zh-Hans.lproj/Localizable.strings
@@ -27,6 +27,11 @@
 "show_more" = "显示更多";
 "show_less" = "收起";
 "top_songs" = "热门歌曲";
+"discography" = "作品";
+"release_group_all" = "全部";
+"release_group_singles_eps" = "单曲和 EP";
+"fans_also_like" = "粉丝也喜欢";
+"more_info" = "更多信息";
 "downloads" = "下载";
 "library" = "音乐库";
 "libraries" = "音乐库";

--- a/Shelv/zh-Hans.lproj/Localizable.strings
+++ b/Shelv/zh-Hans.lproj/Localizable.strings
@@ -25,6 +25,8 @@
 "track_collection_duration_hours_format" = "%d小时";
 "track_collection_duration_hours_minutes_format" = "%d小时%d分钟";
 "show_more" = "显示更多";
+"show_less" = "收起";
+"top_songs" = "热门歌曲";
 "downloads" = "下载";
 "library" = "音乐库";
 "libraries" = "音乐库";

--- a/Shelv/zh-Hans.lproj/Localizable.strings
+++ b/Shelv/zh-Hans.lproj/Localizable.strings
@@ -27,6 +27,9 @@
 "show_more" = "显示更多";
 "show_less" = "收起";
 "top_songs" = "热门歌曲";
+"latest_release" = "最新发行";
+"last_fm" = "Last.fm";
+"musicbrainz" = "MusicBrainz";
 "artist_release_count_format" = "%d 张作品";
 "artist_lastfm_listeners_format" = "%@ 位 Last.fm 听众";
 "artist_world_rank_format" = "本月全球第 %d 位";

--- a/ShelvCore/Models/Album.swift
+++ b/ShelvCore/Models/Album.swift
@@ -15,6 +15,9 @@ nonisolated struct Album: Identifiable, Codable, Hashable, Sendable {
     let playCount: Int?
     var starred: Date?
     let created: Date?
+    /// OpenSubsonic release types ("album", "single", "ep", "compilation", …),
+    /// when the server supplies them.
+    let releaseTypes: [String]?
     var songs: [Song]?
 
     var isStarred: Bool { starred != nil }
@@ -25,7 +28,7 @@ nonisolated struct Album: Identifiable, Codable, Hashable, Sendable {
     }
 
     enum CodingKeys: String, CodingKey {
-        case id, name, sortName, artist, artistId, coverArt, songCount, duration, year, genre, playCount, starred, created
+        case id, name, sortName, artist, artistId, coverArt, songCount, duration, year, genre, playCount, starred, created, releaseTypes
     }
 
     init(
@@ -42,6 +45,7 @@ nonisolated struct Album: Identifiable, Codable, Hashable, Sendable {
         playCount: Int? = nil,
         starred: Date? = nil,
         created: Date? = nil,
+        releaseTypes: [String]? = nil,
         songs: [Song]? = nil
     ) {
         self.id = id
@@ -57,6 +61,7 @@ nonisolated struct Album: Identifiable, Codable, Hashable, Sendable {
         self.playCount = playCount
         self.starred = starred
         self.created = created
+        self.releaseTypes = releaseTypes
         self.songs = songs
     }
 
@@ -75,6 +80,7 @@ nonisolated struct Album: Identifiable, Codable, Hashable, Sendable {
         playCount = try c.decodeIfPresent(Int.self, forKey: .playCount)
         starred = FlexibleDate.decode(c, .starred)
         created = FlexibleDate.decode(c, .created)
+        releaseTypes = try c.decodeIfPresent([String].self, forKey: .releaseTypes)
         songs = nil
     }
 }

--- a/ShelvCore/Services/ArtistDiscography.swift
+++ b/ShelvCore/Services/ArtistDiscography.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+/// The discography filter of the artist page: albums on one side, singles and
+/// EPs on the other.
+nonisolated enum ArtistReleaseGroup: String, CaseIterable, Sendable {
+    case all
+    case albums
+    case singlesAndEPs
+}
+
+/// Sorts an artist's releases into albums and short releases.
+///
+/// OpenSubsonic servers report `releaseTypes` per album, which is the only
+/// authoritative answer. Servers that don't are read from track count and
+/// running time instead, the same signals a listener uses when looking at a
+/// release with two tracks on it.
+nonisolated enum ArtistDiscography {
+    /// A release with at most this many tracks is a single or an EP.
+    static let shortReleaseTrackLimit = 3
+
+    /// Up to this many tracks still counts as an EP when the running time stays
+    /// under `epDurationLimit`.
+    static let epTrackLimit = 6
+
+    /// 30 minutes, the usual boundary between an EP and an album.
+    static let epDurationLimit = 30 * 60
+
+    static func group(for album: Album) -> ArtistReleaseGroup {
+        if let declared = declaredGroup(for: album) { return declared }
+        return inferredGroup(for: album)
+    }
+
+    /// The server's own answer, when it gives one.
+    static func declaredGroup(for album: Album) -> ArtistReleaseGroup? {
+        guard let types = album.releaseTypes, !types.isEmpty else { return nil }
+        let normalized = types.map { $0.lowercased().trimmingCharacters(in: .whitespacesAndNewlines) }
+        if normalized.contains(where: { $0 == "single" || $0 == "ep" }) { return .singlesAndEPs }
+        return .albums
+    }
+
+    /// Track count and running time, for servers without `releaseTypes`.
+    static func inferredGroup(for album: Album) -> ArtistReleaseGroup {
+        let trackCount = album.songCount ?? 0
+        guard trackCount > 0 else { return .albums }
+        if trackCount <= shortReleaseTrackLimit { return .singlesAndEPs }
+        if trackCount <= epTrackLimit, let duration = album.duration, duration < epDurationLimit {
+            return .singlesAndEPs
+        }
+        return .albums
+    }
+
+    static func filter(_ albums: [Album], to group: ArtistReleaseGroup) -> [Album] {
+        guard group != .all else { return albums }
+        return albums.filter { self.group(for: $0) == group }
+    }
+
+    /// The filter is only worth showing when the artist actually has both kinds
+    /// of release. One button that filters nothing is noise.
+    static func availableGroups(for albums: [Album]) -> [ArtistReleaseGroup] {
+        var hasAlbums = false
+        var hasShortReleases = false
+        for album in albums {
+            switch group(for: album) {
+            case .albums: hasAlbums = true
+            case .singlesAndEPs: hasShortReleases = true
+            case .all: break
+            }
+            if hasAlbums && hasShortReleases { return ArtistReleaseGroup.allCases }
+        }
+        return []
+    }
+}

--- a/ShelvCore/Services/ArtistExternalStats.swift
+++ b/ShelvCore/Services/ArtistExternalStats.swift
@@ -1,0 +1,131 @@
+import Foundation
+
+/// Public numbers about an artist, from services outside the music server.
+nonisolated struct ArtistExternalStats: Sendable, Equatable {
+    /// Distinct Last.fm listeners, all time. Last.fm publishes no monthly figure.
+    let listeners: Int?
+    /// Position in this month's ListenBrainz sitewide chart, which only covers
+    /// the top of the chart. Absent for everyone below it.
+    let worldRank: Int?
+
+    static let none = ArtistExternalStats(listeners: nil, worldRank: nil)
+
+    var isEmpty: Bool { listeners == nil && worldRank == nil }
+}
+
+nonisolated enum ArtistExternalStatsSettings {
+    /// Off by default: this is the only part of the app that talks to a server
+    /// other than the user's own.
+    static let enabledKey = "showExternalArtistStats"
+    /// The user's own Last.fm API key. None is shipped with the app.
+    static let lastFMKeyKey = "lastFMAPIKey"
+
+    static var isEnabled: Bool {
+        UserDefaults.standard.bool(forKey: enabledKey)
+    }
+
+    static var lastFMAPIKey: String {
+        (UserDefaults.standard.string(forKey: lastFMKeyKey) ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+/// Reads the ListenBrainz chart and the Last.fm artist page.
+///
+/// Both are optional extras: a failure, a missing key or a missing MusicBrainz
+/// id simply means no numbers, never an error on screen.
+actor ArtistExternalStatsService {
+    static let shared = ArtistExternalStatsService()
+
+    /// One chart request covers every artist, so it is fetched once a day and
+    /// looked up per artist afterwards.
+    private static let chartLifetime: TimeInterval = 24 * 60 * 60
+    private static let chartSize = 1000
+    private static let requestTimeout: TimeInterval = 10
+
+    private var chart: [String: Int] = [:]
+    private var chartFetchedAt: Date?
+    private var cache: [String: ArtistExternalStats] = [:]
+
+    func stats(artistName: String, musicBrainzId: String?) async -> ArtistExternalStats {
+        guard ArtistExternalStatsSettings.isEnabled else { return .none }
+
+        let key = musicBrainzId ?? artistName.lowercased()
+        if let cached = cache[key] { return cached }
+
+        async let listeners = lastFMListeners(artistName: artistName)
+        async let rank = worldRank(musicBrainzId: musicBrainzId)
+        let stats = ArtistExternalStats(listeners: await listeners, worldRank: await rank)
+        cache[key] = stats
+        return stats
+    }
+
+    /// Visible for tests: the chart is a plain ranked list of MusicBrainz ids.
+    static func rank(forMusicBrainzId mbid: String?, in orderedIds: [String?]) -> Int? {
+        guard let mbid, !mbid.isEmpty else { return nil }
+        return orderedIds.firstIndex(of: mbid).map { $0 + 1 }
+    }
+
+    private func lastFMListeners(artistName: String) async -> Int? {
+        let apiKey = ArtistExternalStatsSettings.lastFMAPIKey
+        guard !apiKey.isEmpty, !artistName.isEmpty else { return nil }
+        var components = URLComponents(string: "https://ws.audioscrobbler.com/2.0/")
+        components?.queryItems = [
+            URLQueryItem(name: "method", value: "artist.getinfo"),
+            URLQueryItem(name: "artist", value: artistName),
+            URLQueryItem(name: "api_key", value: apiKey),
+            URLQueryItem(name: "format", value: "json")
+        ]
+        guard let url = components?.url, let data = await fetch(url) else { return nil }
+        struct Response: Decodable {
+            struct Artist: Decodable {
+                struct Stats: Decodable { let listeners: String? }
+                let stats: Stats?
+            }
+            let artist: Artist?
+        }
+        let listeners = (try? JSONDecoder().decode(Response.self, from: data))?.artist?.stats?.listeners
+        return listeners.flatMap(Int.init)
+    }
+
+    private func worldRank(musicBrainzId: String?) async -> Int? {
+        guard let musicBrainzId, !musicBrainzId.isEmpty else { return nil }
+        await refreshChartIfNeeded()
+        return chart[musicBrainzId]
+    }
+
+    private func refreshChartIfNeeded() async {
+        if let chartFetchedAt, Date().timeIntervalSince(chartFetchedAt) < Self.chartLifetime, !chart.isEmpty {
+            return
+        }
+        var components = URLComponents(string: "https://api.listenbrainz.org/1/stats/sitewide/artists")
+        components?.queryItems = [
+            URLQueryItem(name: "range", value: "month"),
+            URLQueryItem(name: "count", value: "\(Self.chartSize)")
+        ]
+        guard let url = components?.url, let data = await fetch(url) else { return }
+        struct Response: Decodable {
+            struct Payload: Decodable {
+                struct Entry: Decodable { let artist_mbid: String? }
+                let artists: [Entry]
+            }
+            let payload: Payload
+        }
+        guard let decoded = try? JSONDecoder().decode(Response.self, from: data) else { return }
+        var ranks: [String: Int] = [:]
+        for (index, entry) in decoded.payload.artists.enumerated() {
+            guard let mbid = entry.artist_mbid, ranks[mbid] == nil else { continue }
+            ranks[mbid] = index + 1
+        }
+        chart = ranks
+        chartFetchedAt = Date()
+    }
+
+    private func fetch(_ url: URL) async -> Data? {
+        var request = URLRequest(url: url, timeoutInterval: Self.requestTimeout)
+        request.setValue("Shelv", forHTTPHeaderField: "User-Agent")
+        guard let (data, response) = try? await URLSession.shared.data(for: request),
+              (response as? HTTPURLResponse)?.statusCode == 200 else { return nil }
+        return data
+    }
+}

--- a/ShelvCore/Services/ArtistTopSongsRanking.swift
+++ b/ShelvCore/Services/ArtistTopSongsRanking.swift
@@ -14,6 +14,13 @@ nonisolated enum ArtistTopSongsRanking {
     /// per release just to fill a five-row list.
     static let fallbackAlbumLimit = 25
 
+    /// What `getTopSongs` is asked for, which is NOT the number of songs it
+    /// answers with: Navidrome reads that many entries from its ranking source
+    /// and then keeps the ones that exist in the library. Asking for 10 returned
+    /// 2 songs for one artist here, asking for 100 returned 15, at the same
+    /// cost of one request. Ask wide, show `limit`.
+    static let serverScanCount = 100
+
     /// The server ranking, kept in the order the server sent it.
     static func rankServerSongs(_ songs: [Song], limit: Int = limit) -> [Song] {
         Array(deduplicatedByTitle(songs).prefix(limit))

--- a/ShelvCore/Services/ArtistTopSongsRanking.swift
+++ b/ShelvCore/Services/ArtistTopSongsRanking.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// The ordering rules behind the top-songs section of the artist pages,
+/// kept free of any network call so they can be tested on their own.
+nonisolated enum ArtistTopSongsRanking {
+    /// Songs kept for the section.
+    static let limit = 10
+
+    /// Songs shown before the section is expanded.
+    static let collapsedLimit = 5
+
+    /// Albums scanned by the play-count fallback, most played first. Artists
+    /// with a deep back catalogue would otherwise fan out one album request
+    /// per release just to fill a five-row list.
+    static let fallbackAlbumLimit = 25
+
+    /// The server ranking, kept in the order the server sent it.
+    static func rankServerSongs(_ songs: [Song], limit: Int = limit) -> [Song] {
+        Array(deduplicatedByTitle(songs).prefix(limit))
+    }
+
+    /// The albums worth scanning when the server has no ranking, most played
+    /// first so the cap keeps the tracks that can actually reach the top.
+    static func fallbackAlbums(from albums: [Album]) -> [Album] {
+        Array(
+            albums
+                .sorted { ($0.playCount ?? 0) > ($1.playCount ?? 0) }
+                .prefix(fallbackAlbumLimit)
+        )
+    }
+
+    /// Fallback ranking: the artist's own tracks ordered by the play counts
+    /// reported by the server. Never-played tracks are dropped, an untouched
+    /// library has no top songs and should show none.
+    static func rankByPlayCount(_ songs: [Song], limit: Int = limit) -> [Song] {
+        let played = songs.filter { ($0.playCount ?? 0) > 0 }
+        guard !played.isEmpty else { return [] }
+        let ordered = played.sorted { ($0.playCount ?? 0) > ($1.playCount ?? 0) }
+        return Array(deduplicatedByTitle(ordered).prefix(limit))
+    }
+
+    /// Keeps the first occurrence of every title. Libraries routinely hold the
+    /// same track on an album, on a single and on a compilation, and a top list
+    /// that repeats itself is worse than a shorter one.
+    private static func deduplicatedByTitle(_ songs: [Song]) -> [Song] {
+        var seen = Set<String>()
+        return songs.filter { song in
+            let key = song.title
+                .folding(options: [.diacriticInsensitive, .caseInsensitive], locale: nil)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            return seen.insert(key).inserted
+        }
+    }
+}

--- a/ShelvCore/Services/ArtistTopSongsService.swift
+++ b/ShelvCore/Services/ArtistTopSongsService.swift
@@ -18,7 +18,10 @@ nonisolated enum ArtistTopSongsService {
         loadAlbumSongs: @escaping @Sendable (String) async -> [Song]
     ) async -> [Song] {
         let ranked = ArtistTopSongsRanking.rankServerSongs(
-            await fetchServerRanking(artistName: artistName, limit: limit),
+            await fetchServerRanking(
+                artistName: artistName,
+                count: ArtistTopSongsRanking.serverScanCount
+            ),
             limit: limit
         )
         guard ranked.isEmpty else { return ranked }
@@ -33,11 +36,11 @@ nonisolated enum ArtistTopSongsService {
         return ArtistTopSongsRanking.rankByPlayCount(songs, limit: limit)
     }
 
-    private static func fetchServerRanking(artistName: String, limit: Int) async -> [Song] {
+    private static func fetchServerRanking(artistName: String, count: Int) async -> [Song] {
         guard !artistName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return [] }
         return (try? await SubsonicAPIService.shared.getTopSongs(
             artistName: artistName,
-            count: limit,
+            count: count,
             retries: 1
         )) ?? []
     }

--- a/ShelvCore/Services/ArtistTopSongsService.swift
+++ b/ShelvCore/Services/ArtistTopSongsService.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// Ranked top songs for the artist detail pages.
+///
+/// The server ranking (`getTopSongs`) comes first: Navidrome backs it with
+/// Last.fm and only returns tracks that exist in the library. Servers without
+/// that data answer with an empty list, so the play counts the server already
+/// reports for the artist's own tracks are used as a fallback ranking. When
+/// neither source has anything to rank, the section stays hidden rather than
+/// showing an arbitrary track list.
+///
+/// The ordering itself lives in `ArtistTopSongsRanking`.
+nonisolated enum ArtistTopSongsService {
+    static func topSongs(
+        artistName: String,
+        albums: [Album],
+        limit: Int = ArtistTopSongsRanking.limit,
+        loadAlbumSongs: @escaping @Sendable (String) async -> [Song]
+    ) async -> [Song] {
+        let ranked = ArtistTopSongsRanking.rankServerSongs(
+            await fetchServerRanking(artistName: artistName, limit: limit),
+            limit: limit
+        )
+        guard ranked.isEmpty else { return ranked }
+
+        let scanned = ArtistTopSongsRanking.fallbackAlbums(from: albums)
+        guard !scanned.isEmpty else { return [] }
+
+        let songs = await PlaybackContentResolver.artistSongs(
+            from: scanned,
+            loadAlbumSongs: loadAlbumSongs
+        )
+        return ArtistTopSongsRanking.rankByPlayCount(songs, limit: limit)
+    }
+
+    private static func fetchServerRanking(artistName: String, limit: Int) async -> [Song] {
+        guard !artistName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return [] }
+        return (try? await SubsonicAPIService.shared.getTopSongs(
+            artistName: artistName,
+            count: limit,
+            retries: 1
+        )) ?? []
+    }
+}

--- a/ShelvCore/Services/DemoContent.swift
+++ b/ShelvCore/Services/DemoContent.swift
@@ -34,11 +34,16 @@ nonisolated enum DemoContent {
         let artistKey: String
         let artistName: String
         let year: Int
+        /// OpenSubsonic release types, so the demo shows the discography filter.
+        var releaseTypes: [String]? = nil
+        /// Short releases reuse the cover of the artist's album, the asset
+        /// catalogue holds one image per album key.
+        var coverKey: String? = nil
         let tracks: [(String, Int)]   // (Titel, Sekunden)
 
         var albumId: String { "demo-album-\(key)" }
         var artistId: String { "demo-artist-\(artistKey)" }
-        var cover: String { "demo_cover_\(key)" }
+        var cover: String { "demo_cover_\(coverKey ?? key)" }
     }
 
     private static let specs: [AlbumSpec] = [
@@ -88,6 +93,27 @@ nonisolated enum DemoContent {
             ("Dune", 213), ("Ruins of Quiet", 298), ("Sandglass", 191), ("Heat Mirage", 245),
             ("Empty Quarter", 268), ("Goldenrod", 202), ("Last Oasis", 257),
         ]),
+        AlbumSpec(key: "carrier_wave", title: "Carrier Wave", artistKey: "deadlight_protocol",
+                  artistName: "Deadlight Protocol", year: 2025,
+                  releaseTypes: ["single"], coverKey: "depth_unknown", tracks: [
+            ("Carrier Wave", 268),
+        ]),
+        AlbumSpec(key: "night_watch", title: "Night Watch", artistKey: "deadlight_protocol",
+                  artistName: "Deadlight Protocol", year: 2023,
+                  releaseTypes: ["ep"], coverKey: "depth_unknown", tracks: [
+            ("Night Watch", 241), ("Signal Drift", 197), ("Watchtower", 263),
+        ]),
+        AlbumSpec(key: "second_light", title: "Second Light", artistKey: "deadlight_protocol",
+                  artistName: "Deadlight Protocol", year: 2021,
+                  releaseTypes: ["album"], coverKey: "depth_unknown", tracks: [
+            ("Second Light", 224), ("Ash Field", 251), ("Undertone", 196), ("Coastline", 268),
+            ("Half Signal", 233), ("Second Dark", 289),
+        ]),
+        AlbumSpec(key: "quiet_hands_single", title: "Quiet Hands", artistKey: "pale_signal",
+                  artistName: "Pale Signal", year: 2021,
+                  releaseTypes: ["single"], coverKey: "after_last_light", tracks: [
+            ("Quiet Hands (Live)", 214),
+        ]),
     ]
 
     // MARK: - Abgeleitete Objekte
@@ -108,7 +134,7 @@ nonisolated enum DemoContent {
                      artistId: spec.artistId, coverArt: spec.cover, songCount: s.count,
                      duration: s.reduce(0) { $0 + ($1.duration ?? 0) }, year: spec.year,
                      genre: "Ambient", playCount: s.reduce(0) { $0 + ($1.playCount ?? 0) },
-                     starred: nil, created: nil)
+                     starred: nil, created: nil, releaseTypes: spec.releaseTypes)
     }
 
     static let albums: [Album] = specs.map(album(for:))
@@ -119,10 +145,15 @@ nonisolated enum DemoContent {
     private static let albumById: [String: Album] =
         Dictionary(uniqueKeysWithValues: albums.map { ($0.id, $0) })
 
-    static let artists: [Artist] = specs.map { spec in
-        Artist(id: spec.artistId, name: spec.artistName, albumCount: 1,
-               coverArt: "demo_artist_\(spec.artistKey)", starred: nil)
-    }
+    static let artists: [Artist] = {
+        var seen = Set<String>()
+        return specs.compactMap { spec in
+            guard seen.insert(spec.artistId).inserted else { return nil }
+            let releases = specs.filter { $0.artistId == spec.artistId }.count
+            return Artist(id: spec.artistId, name: spec.artistName, albumCount: releases,
+                          coverArt: "demo_artist_\(spec.artistKey)", starred: nil)
+        }
+    }()
 
     // MARK: - API-Antworten
 
@@ -141,10 +172,10 @@ nonisolated enum DemoContent {
             + "This biography is part of the demo library and does not describe a real artist."
         }
         guard similarArtistCount > 0 else {
-            return ArtistInfo(biography: biography, similarArtist: nil)
+            return ArtistInfo(biography: biography, similarArtist: nil, musicBrainzId: nil)
         }
         let others = artists.filter { $0.id != id }.prefix(similarArtistCount)
-        return ArtistInfo(biography: biography, similarArtist: Array(others))
+        return ArtistInfo(biography: biography, similarArtist: Array(others), musicBrainzId: nil)
     }
 
     static func artistDetail(id: String) -> ArtistDetail? {

--- a/ShelvCore/Services/DemoContent.swift
+++ b/ShelvCore/Services/DemoContent.swift
@@ -172,10 +172,10 @@ nonisolated enum DemoContent {
             + "This biography is part of the demo library and does not describe a real artist."
         }
         guard similarArtistCount > 0 else {
-            return ArtistInfo(biography: biography, similarArtist: nil, musicBrainzId: nil)
+            return ArtistInfo(biography: biography, similarArtist: nil, musicBrainzId: nil, lastFmUrl: nil)
         }
         let others = artists.filter { $0.id != id }.prefix(similarArtistCount)
-        return ArtistInfo(biography: biography, similarArtist: Array(others), musicBrainzId: nil)
+        return ArtistInfo(biography: biography, similarArtist: Array(others), musicBrainzId: nil, lastFmUrl: nil)
     }
 
     static func artistDetail(id: String) -> ArtistDetail? {

--- a/ShelvCore/Services/DemoContent.swift
+++ b/ShelvCore/Services/DemoContent.swift
@@ -133,6 +133,20 @@ nonisolated enum DemoContent {
                            year: a.year, genre: a.genre, song: songsByAlbumId[id])
     }
 
+    /// Biography and related artists for the artist page. The other demo
+    /// artists stand in for what a server returns as similar artists.
+    static func artistInfo(id: String, similarArtistCount: Int) -> ArtistInfo {
+        let biography = artists.first(where: { $0.id == id }).map {
+            "\($0.name) records slow, wide ambient pieces built from field recordings and analogue tape. "
+            + "This biography is part of the demo library and does not describe a real artist."
+        }
+        guard similarArtistCount > 0 else {
+            return ArtistInfo(biography: biography, similarArtist: nil)
+        }
+        let others = artists.filter { $0.id != id }.prefix(similarArtistCount)
+        return ArtistInfo(biography: biography, similarArtist: Array(others))
+    }
+
     static func artistDetail(id: String) -> ArtistDetail? {
         guard let artist = artists.first(where: { $0.id == id }) else { return nil }
         let owned = albums.filter { $0.artistId == id }

--- a/ShelvCore/Services/SubsonicAPIService.swift
+++ b/ShelvCore/Services/SubsonicAPIService.swift
@@ -325,6 +325,8 @@ nonisolated struct ArtistInfo: Decodable, Sendable {
     let similarArtist: [Artist]?
     /// Identifies the artist outside the server, for services that key on it.
     let musicBrainzId: String?
+    /// The artist's Last.fm page, when the server resolved one.
+    let lastFmUrl: String?
 }
 
 nonisolated struct SearchResult: Decodable, Sendable {
@@ -1506,7 +1508,7 @@ nonisolated class SubsonicAPIService: ObservableObject, @unchecked Sendable {
             URLQueryItem(name: "count", value: "\(similarArtistCount)")
         ]).response
         try check(status: body.status, error: body.error)
-        return body.artistInfo2 ?? ArtistInfo(biography: nil, similarArtist: nil, musicBrainzId: nil)
+        return body.artistInfo2 ?? ArtistInfo(biography: nil, similarArtist: nil, musicBrainzId: nil, lastFmUrl: nil)
     }
 
     func getSong(id: String, retries: Int = 0) async throws -> Song {

--- a/ShelvCore/Services/SubsonicAPIService.swift
+++ b/ShelvCore/Services/SubsonicAPIService.swift
@@ -323,6 +323,8 @@ nonisolated struct ArtistInfo: Decodable, Sendable {
     /// Artists the server considers related. Navidrome only returns the ones
     /// present in the library, so every entry is browsable.
     let similarArtist: [Artist]?
+    /// Identifies the artist outside the server, for services that key on it.
+    let musicBrainzId: String?
 }
 
 nonisolated struct SearchResult: Decodable, Sendable {
@@ -1504,7 +1506,7 @@ nonisolated class SubsonicAPIService: ObservableObject, @unchecked Sendable {
             URLQueryItem(name: "count", value: "\(similarArtistCount)")
         ]).response
         try check(status: body.status, error: body.error)
-        return body.artistInfo2 ?? ArtistInfo(biography: nil, similarArtist: nil)
+        return body.artistInfo2 ?? ArtistInfo(biography: nil, similarArtist: nil, musicBrainzId: nil)
     }
 
     func getSong(id: String, retries: Int = 0) async throws -> Song {

--- a/ShelvCore/Services/SubsonicAPIService.swift
+++ b/ShelvCore/Services/SubsonicAPIService.swift
@@ -320,6 +320,9 @@ nonisolated struct ArtistDetail: Decodable, Identifiable, Sendable {
 
 nonisolated struct ArtistInfo: Decodable, Sendable {
     let biography: String?
+    /// Artists the server considers related. Navidrome only returns the ones
+    /// present in the library, so every entry is browsable.
+    let similarArtist: [Artist]?
 }
 
 nonisolated struct SearchResult: Decodable, Sendable {
@@ -1489,16 +1492,19 @@ nonisolated class SubsonicAPIService: ObservableObject, @unchecked Sendable {
         return await filteredArtistDetailForActiveLibrary(artist)
     }
 
-    func getArtistInfo(id: String) async throws -> ArtistInfo {
+    /// - Parameter similarArtistCount: how many related artists the server should
+    ///   return. `getArtistInfo2` sends none at all when this is zero, which is
+    ///   what the biography-only callers want.
+    func getArtistInfo(id: String, similarArtistCount: Int = 0) async throws -> ArtistInfo {
         #if DEBUG
-        if isDemoActive { return ArtistInfo(biography: nil) }
+        if isDemoActive { return DemoContent.artistInfo(id: id, similarArtistCount: similarArtistCount) }
         #endif
         let body = try await fetchDecoded(Envelope<ArtistInfoBody>.self, path: "getArtistInfo2", extra: [
             URLQueryItem(name: "id", value: id),
-            URLQueryItem(name: "count", value: "0")
+            URLQueryItem(name: "count", value: "\(similarArtistCount)")
         ]).response
         try check(status: body.status, error: body.error)
-        return body.artistInfo2 ?? ArtistInfo(biography: nil)
+        return body.artistInfo2 ?? ArtistInfo(biography: nil, similarArtist: nil)
     }
 
     func getSong(id: String, retries: Int = 0) async throws -> Song {

--- a/ShelvCore/Support/ArtistPageLayout.swift
+++ b/ShelvCore/Support/ArtistPageLayout.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+/// Sizing shared by the artist pages of every platform.
+nonisolated enum ArtistPageLayout {
+    /// Related artists requested from the server for the "fans also like" row.
+    /// `getArtistInfo2` returns none at all when this is zero.
+    static let similarArtistCount = 12
+}

--- a/ShelvTests/ArtistDiscographyTests.swift
+++ b/ShelvTests/ArtistDiscographyTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+
+final class ArtistDiscographyTests: XCTestCase {
+    private func album(
+        id: String,
+        songCount: Int? = nil,
+        duration: Int? = nil,
+        releaseTypes: [String]? = nil
+    ) -> Album {
+        Album(id: id, name: "Album \(id)", songCount: songCount, duration: duration, releaseTypes: releaseTypes)
+    }
+
+    func testServerReleaseTypesWinOverTrackCount() {
+        let longSingle = album(id: "1", songCount: 12, duration: 3_600, releaseTypes: ["single"])
+        let shortAlbum = album(id: "2", songCount: 2, duration: 300, releaseTypes: ["Album"])
+
+        XCTAssertEqual(ArtistDiscography.group(for: longSingle), .singlesAndEPs)
+        XCTAssertEqual(ArtistDiscography.group(for: shortAlbum), .albums)
+    }
+
+    func testReleaseTypesAreCaseAndWhitespaceInsensitive() {
+        XCTAssertEqual(ArtistDiscography.group(for: album(id: "1", releaseTypes: [" EP "])), .singlesAndEPs)
+        XCTAssertEqual(ArtistDiscography.group(for: album(id: "2", releaseTypes: ["COMPILATION"])), .albums)
+    }
+
+    func testEmptyReleaseTypesFallBackToTheHeuristic() {
+        XCTAssertNil(ArtistDiscography.declaredGroup(for: album(id: "1", releaseTypes: [])))
+        XCTAssertEqual(ArtistDiscography.group(for: album(id: "1", songCount: 2, releaseTypes: [])), .singlesAndEPs)
+    }
+
+    func testShortTrackCountsAreSinglesWithoutServerMetadata() {
+        XCTAssertEqual(ArtistDiscography.group(for: album(id: "1", songCount: 1, duration: 240)), .singlesAndEPs)
+        XCTAssertEqual(ArtistDiscography.group(for: album(id: "2", songCount: 3, duration: 700)), .singlesAndEPs)
+    }
+
+    func testShortRunningTimeMakesAnEPButALongOneStaysAnAlbum() {
+        XCTAssertEqual(ArtistDiscography.group(for: album(id: "1", songCount: 5, duration: 1_500)), .singlesAndEPs)
+        XCTAssertEqual(ArtistDiscography.group(for: album(id: "2", songCount: 5, duration: 2_400)), .albums)
+    }
+
+    func testUnknownTrackCountIsTreatedAsAnAlbum() {
+        XCTAssertEqual(ArtistDiscography.group(for: album(id: "1")), .albums)
+        XCTAssertEqual(ArtistDiscography.group(for: album(id: "2", songCount: 0)), .albums)
+    }
+
+    func testFilterKeepsEverythingForTheAllGroup() {
+        let albums = [album(id: "1", songCount: 10, duration: 3_000), album(id: "2", songCount: 1)]
+        XCTAssertEqual(ArtistDiscography.filter(albums, to: .all).map { $0.id }, ["1", "2"])
+        XCTAssertEqual(ArtistDiscography.filter(albums, to: .albums).map { $0.id }, ["1"])
+        XCTAssertEqual(ArtistDiscography.filter(albums, to: .singlesAndEPs).map { $0.id }, ["2"])
+    }
+
+    func testFilterIsHiddenUnlessBothKindsExist() {
+        let onlyAlbums = [album(id: "1", songCount: 10, duration: 3_000)]
+        let onlySingles = [album(id: "2", songCount: 1)]
+        let mixed = onlyAlbums + onlySingles
+
+        XCTAssertTrue(ArtistDiscography.availableGroups(for: onlyAlbums).isEmpty)
+        XCTAssertTrue(ArtistDiscography.availableGroups(for: onlySingles).isEmpty)
+        XCTAssertTrue(ArtistDiscography.availableGroups(for: []).isEmpty)
+        XCTAssertEqual(ArtistDiscography.availableGroups(for: mixed), ArtistReleaseGroup.allCases)
+    }
+}

--- a/ShelvTests/ArtistTopSongsRankingTests.swift
+++ b/ShelvTests/ArtistTopSongsRankingTests.swift
@@ -1,0 +1,77 @@
+import XCTest
+
+final class ArtistTopSongsRankingTests: XCTestCase {
+    func testServerRankingKeepsServerOrderAndDropsRepeatedTitles() {
+        let songs = [
+            Song(id: "1", title: "Yellow", playCount: 2),
+            Song(id: "2", title: "Sparks", playCount: 99),
+            // Same track from a compilation: the server returns both.
+            Song(id: "3", title: "yellow ", playCount: 1),
+            Song(id: "4", title: "Trouble")
+        ]
+
+        let ranked = ArtistTopSongsRanking.rankServerSongs(songs)
+
+        XCTAssertEqual(ranked.map { $0.id }, ["1", "2", "4"])
+    }
+
+    func testServerRankingHonoursTheLimit() {
+        let songs = (1...12).map { Song(id: "\($0)", title: "Track \($0)") }
+
+        XCTAssertEqual(ArtistTopSongsRanking.rankServerSongs(songs, limit: 5).count, 5)
+        XCTAssertEqual(ArtistTopSongsRanking.rankServerSongs(songs).count, ArtistTopSongsRanking.limit)
+    }
+
+    func testPlayCountFallbackOrdersByPlayCountAndIgnoresUnplayedTracks() {
+        let songs = [
+            Song(id: "1", title: "Never played"),
+            Song(id: "2", title: "Played twice", playCount: 2),
+            Song(id: "3", title: "Played once", playCount: 1),
+            Song(id: "4", title: "Played a lot", playCount: 40),
+            Song(id: "5", title: "Played zero times", playCount: 0)
+        ]
+
+        let ranked = ArtistTopSongsRanking.rankByPlayCount(songs)
+
+        XCTAssertEqual(ranked.map { $0.id }, ["4", "2", "3"])
+    }
+
+    func testPlayCountFallbackReturnsNothingWhenNoTrackWasEverPlayed() {
+        let songs = [
+            Song(id: "1", title: "One"),
+            Song(id: "2", title: "Two", playCount: 0)
+        ]
+
+        XCTAssertTrue(ArtistTopSongsRanking.rankByPlayCount(songs).isEmpty)
+    }
+
+    func testPlayCountFallbackKeepsTheMostPlayedCopyOfADuplicatedTitle() {
+        let songs = [
+            Song(id: "album", title: "Peace", playCount: 12),
+            Song(id: "single", title: "PEACE", playCount: 3)
+        ]
+
+        XCTAssertEqual(ArtistTopSongsRanking.rankByPlayCount(songs).map { $0.id }, ["album"])
+    }
+
+    func testFallbackScansTheMostPlayedAlbumsFirstAndCapsTheFanOut() {
+        let albums = (1...40).map { (index: Int) in
+            Album(id: "\(index)", name: "Album \(index)", playCount: index)
+        }
+
+        let scanned = ArtistTopSongsRanking.fallbackAlbums(from: albums)
+
+        XCTAssertEqual(scanned.count, ArtistTopSongsRanking.fallbackAlbumLimit)
+        XCTAssertEqual(scanned.first?.id, "40")
+        XCTAssertEqual(scanned.last?.id, "16")
+    }
+
+    func testFallbackHandlesAlbumsWithoutPlayCounts() {
+        let albums = [
+            Album(id: "unplayed", name: "Unplayed"),
+            Album(id: "played", name: "Played", playCount: 5)
+        ]
+
+        XCTAssertEqual(ArtistTopSongsRanking.fallbackAlbums(from: albums).first?.id, "played")
+    }
+}


### PR DESCRIPTION
Closes #36

## What this does

The artist page listed albums and ended with a bare biography. This reworks it into the shape people expect from a music app: what to listen to first, then the discography, then where to go next. iOS and macOS get the same treatment, and the list layout keeps its filter since it stays one list.

| Artist page | Related artists and about |
|---|---|
| <img alt="Artist page with banner, counts and top songs" src="https://github.com/user-attachments/assets/08a3bfae-1588-4a6d-a948-36cd584ce2dd" /> | <img alt="Latest release, fans also like and more info" src="https://github.com/user-attachments/assets/4a839711-334e-48e2-89b7-2211170adf26" /> |

Both shots are the demo library, so no real server data is shown.

## Sections

**Top songs.** `getTopSongs` was already implemented in `SubsonicAPIService`, but it only seeded instant mixes, so no artist page ever showed a ranking. The server ranking comes first. When the server returns nothing, which happens both for individual artists and for every artist on a server with no Last.fm key, the artist's own tracks are ranked by the play counts the server already reports. Never-played tracks are dropped, so an untouched library shows no section rather than an arbitrary track list.

**Discography.** Albums and short releases are split apart. OpenSubsonic servers report `releaseTypes`, which settles it. Servers that do not are read from track count and running time, with 3 tracks or fewer, or 6 tracks under 30 minutes, counting as a single or EP. The filter only appears when the artist actually has both kinds of release, so it never shows a button that filters nothing.

**Fans also like.** `getArtistInfo2` already returned similar artists, but the app asked for `count=0` and decoded only the biography, so they were thrown away. The artist pages now request 12 and show them as a row of browsable artists. Navidrome only returns artists present in the library, so every entry opens.

**Banner and counts.** The page opens on the artist photo the server already holds, with the name, release count and play count over it. Servers hand out square images, so the square is cropped to a band around its centre. Artists without a photo keep the compact header.

**More info.** The biography keeps its expand behaviour and gains a section title plus Last.fm and MusicBrainz links, so the end of the page reads as a section rather than a loose paragraph.

The demo library gained a biography, related artists, a single, an EP and a second album, otherwise the new sections are invisible in demo mode.

## One finding worth flagging

`count` on `getTopSongs` is not the number of songs the server returns. Navidrome reads that many entries from its ranking source, then keeps only the ones present in the library. Measured on a real library, one request and about 0.4s in every case:

| count requested | songs returned |
|---|---|
| 10 | 2 |
| 20 | 4 |
| 50 | 12 |
| 100 | 15 |

The service now asks for 100 and displays the first `limit`. That is the difference between a section that looks broken and one that fills up.

Going through Last.fm directly is worse, for the record: matching the 100 tracks of `artist.getTopTracks` against the library gave 2 strict matches and 6 with lenient normalisation, against 15 from the server. Navidrome matches using its own metadata, so there is no point redoing that work client side.

## Privacy

No new request is made in offline mode. The optional public figures, Last.fm listener count and ListenBrainz monthly chart position, ship disabled and require the user's own Last.fm API key. None is bundled. This is the only request the app makes to anything other than the user's own server, which is why it is off by default.

Navidrome cannot supply either figure itself: `getArtistInfo2` carries only the biography, images, similar artists and the MusicBrainz id, and the server configuration is not readable over the API.

## Tests

Ranking and discography rules live in pure types with unit tests, `ArtistTopSongsRanking` and `ArtistDiscography`, following the split already used by `PlayLogReconciliationLogic` and `RecapSyncLogic`. The network side stays in the services. iOS builds and the unit test suite passes, macOS builds and launches.

Tested against Navidrome 0.63.2.

## Happy to split this

The public figures are the most debatable part, since they are the only outbound calls in the app. Say the word and I will pull them into a separate PR and keep this one to the sections that only use the user's own server.
