### PR TITLE
feat: ask the server which OpenSubsonic extensions it supports

### DIFF
--- a/Shelv.xcodeproj/project.pbxproj
+++ b/Shelv.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		11F3AAFBB4684ECFABA0E3E5 /* ShelvCore/Models/RecapPeriod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3481C1649E04481CA0F35E60 /* ShelvCore/Models/RecapPeriod.swift */; };
 		4B666BEAD970D72DFCFF9C7E /* ShelvCore/Services/RadioStationChangeLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8C9F16F5098EE7158A393F2 /* ShelvCore/Services/RadioStationChangeLogic.swift */; };
+		BBF00507000000000000C0DE /* ShelvCore/Support/OpenSubsonicCapabilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF00507000000000000C0DE /* ShelvCore/Support/OpenSubsonicCapabilities.swift */; };
 		4C9CE80450C542811BFC06B9 /* ShelvCore/Services/ArtistTopSongsRanking.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2D3956FCB8E5BA0EA7B365B /* ShelvCore/Services/ArtistTopSongsRanking.swift */; };
 		BBF091A70FDE00000000C0DE /* ShelvCore/Services/ArtistPlayOrder.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF091A70FDE00000000C0DE /* ShelvCore/Services/ArtistPlayOrder.swift */; };
 		54755D0F4F7624D1CB2AFAA0 /* ShelvCore/Services/RemoteStreamFailureRetryPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D76D0722C024A55F5646646B /* ShelvCore/Services/RemoteStreamFailureRetryPolicy.swift */; };
@@ -56,7 +57,6 @@
 		BC1001502FFE000000000001 /* ShelvCore/Services/SubsonicResponseCompatibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1001512FFE000000000001 /* ShelvCore/Services/SubsonicResponseCompatibility.swift */; };
 		BC1001522FFE000000000001 /* ShelvCore/Stores/SearchHistoryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1001532FFE000000000001 /* ShelvCore/Stores/SearchHistoryStore.swift */; };
 		BC1001542FFE000000000001 /* ShelvCore/Support/AlphabetIndexSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1001552FFE000000000001 /* ShelvCore/Support/AlphabetIndexSelection.swift */; };
-		BBF00507000000000000C0DE /* ShelvCore/Support/OpenSubsonicCapabilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF00507000000000000C0DE /* ShelvCore/Support/OpenSubsonicCapabilities.swift */; };
 		BC1001602FFE000000000001 /* ShelvCore/Services/InfinityMixPoolBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1001612FFE000000000001 /* ShelvCore/Services/InfinityMixPoolBuilder.swift */; };
 		BC1867E52F91A088006D96E2 /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = BC1867E42F91A088006D96E2 /* GRDB */; };
 		BC51161D2FDC8A850011CDE9 /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = BC51161C2FDC8A850011CDE9 /* GRDB */; };
@@ -143,7 +143,6 @@
 		BC1001512FFE000000000001 /* ShelvCore/Services/SubsonicResponseCompatibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/SubsonicResponseCompatibility.swift; sourceTree = "<group>"; };
 		BC1001532FFE000000000001 /* ShelvCore/Stores/SearchHistoryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Stores/SearchHistoryStore.swift; sourceTree = "<group>"; };
 		BC1001552FFE000000000001 /* ShelvCore/Support/AlphabetIndexSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Support/AlphabetIndexSelection.swift; sourceTree = "<group>"; };
-		AAF00507000000000000C0DE /* ShelvCore/Support/OpenSubsonicCapabilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Support/OpenSubsonicCapabilities.swift; sourceTree = "<group>"; };
 		BC1001612FFE000000000001 /* ShelvCore/Services/InfinityMixPoolBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/InfinityMixPoolBuilder.swift; sourceTree = "<group>"; };
 		BC2000012FFE000000000001 /* ShelvAppIntentsUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ShelvAppIntentsUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BC5116112FDC8A690011CDE9 /* Shelv TV.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Shelv TV.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -151,6 +150,7 @@
 		BC7B83F52FDB17700058CB78 /* Shelv.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Shelv.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BC9C59382F8E9FB000FF4D25 /* Shelv.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Shelv.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C8C9F16F5098EE7158A393F2 /* ShelvCore/Services/RadioStationChangeLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/RadioStationChangeLogic.swift; sourceTree = "<group>"; };
+		AAF00507000000000000C0DE /* ShelvCore/Support/OpenSubsonicCapabilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Support/OpenSubsonicCapabilities.swift; sourceTree = "<group>"; };
 		D602F58338426465B1E367C5 /* ShelvCore/Services/RecapExpectedSongsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/RecapExpectedSongsLogic.swift; sourceTree = "<group>"; };
 		D76D0722C024A55F5646646B /* ShelvCore/Services/RemoteStreamFailureRetryPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/RemoteStreamFailureRetryPolicy.swift; sourceTree = "<group>"; };
 		DB776033CC96417A93CA66DB /* ShelvCore/Services/ConcurrencyLimiter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/ConcurrencyLimiter.swift; sourceTree = "<group>"; };
@@ -280,6 +280,7 @@
 				BC1001232FFE000000000001 /* ShelvCore/Models/RadioStation.swift */,
 				BC1001272FFE000000000001 /* ShelvCore/Models/SubsonicServer.swift */,
 				C8C9F16F5098EE7158A393F2 /* ShelvCore/Services/RadioStationChangeLogic.swift */,
+				AAF00507000000000000C0DE /* ShelvCore/Support/OpenSubsonicCapabilities.swift */,
 				7032627BABC540CC8752182E /* ShelvCore/Services/PlaylistDuplicateChecker.swift */,
 				FFBB0EAEC930A6AA93845AF6 /* ShelvCore/Services/ArtistDiscography.swift */,
 				F2D3956FCB8E5BA0EA7B365B /* ShelvCore/Services/ArtistTopSongsRanking.swift */,
@@ -320,7 +321,6 @@
 				BC1001512FFE000000000001 /* ShelvCore/Services/SubsonicResponseCompatibility.swift */,
 				BC1001532FFE000000000001 /* ShelvCore/Stores/SearchHistoryStore.swift */,
 				BC1001552FFE000000000001 /* ShelvCore/Support/AlphabetIndexSelection.swift */,
-				AAF00507000000000000C0DE /* ShelvCore/Support/OpenSubsonicCapabilities.swift */,
 				BC10014D2FFE000000000001 /* ShelvCore/Stores/DownloadUIStateHub.swift */,
 			);
 			name = "ShelvCore Test Sources";
@@ -634,6 +634,7 @@
 				BC1001222FFE000000000001 /* ShelvCore/Models/RadioStation.swift in Sources */,
 				BC1001262FFE000000000001 /* ShelvCore/Models/SubsonicServer.swift in Sources */,
 				4B666BEAD970D72DFCFF9C7E /* ShelvCore/Services/RadioStationChangeLogic.swift in Sources */,
+				BBF00507000000000000C0DE /* ShelvCore/Support/OpenSubsonicCapabilities.swift in Sources */,
 				767C48F98385493A929D3CF5 /* ShelvCore/Services/PlaylistDuplicateChecker.swift in Sources */,
 				A3BC3F4796D89CE06D73AEBA /* ShelvCore/Services/ArtistDiscography.swift in Sources */,
 				4C9CE80450C542811BFC06B9 /* ShelvCore/Services/ArtistTopSongsRanking.swift in Sources */,
@@ -674,7 +675,6 @@
 				BC1001502FFE000000000001 /* ShelvCore/Services/SubsonicResponseCompatibility.swift in Sources */,
 				BC1001522FFE000000000001 /* ShelvCore/Stores/SearchHistoryStore.swift in Sources */,
 				BC1001542FFE000000000001 /* ShelvCore/Support/AlphabetIndexSelection.swift in Sources */,
-				BBF00507000000000000C0DE /* ShelvCore/Support/OpenSubsonicCapabilities.swift in Sources */,
 				BC10014C2FFE000000000001 /* ShelvCore/Stores/DownloadUIStateHub.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Shelv.xcodeproj/project.pbxproj
+++ b/Shelv.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		BC1001502FFE000000000001 /* ShelvCore/Services/SubsonicResponseCompatibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1001512FFE000000000001 /* ShelvCore/Services/SubsonicResponseCompatibility.swift */; };
 		BC1001522FFE000000000001 /* ShelvCore/Stores/SearchHistoryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1001532FFE000000000001 /* ShelvCore/Stores/SearchHistoryStore.swift */; };
 		BC1001542FFE000000000001 /* ShelvCore/Support/AlphabetIndexSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1001552FFE000000000001 /* ShelvCore/Support/AlphabetIndexSelection.swift */; };
+		BBF00507000000000000C0DE /* ShelvCore/Support/OpenSubsonicCapabilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF00507000000000000C0DE /* ShelvCore/Support/OpenSubsonicCapabilities.swift */; };
 		BC1001602FFE000000000001 /* ShelvCore/Services/InfinityMixPoolBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1001612FFE000000000001 /* ShelvCore/Services/InfinityMixPoolBuilder.swift */; };
 		BC1867E52F91A088006D96E2 /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = BC1867E42F91A088006D96E2 /* GRDB */; };
 		BC51161D2FDC8A850011CDE9 /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = BC51161C2FDC8A850011CDE9 /* GRDB */; };
@@ -142,6 +143,7 @@
 		BC1001512FFE000000000001 /* ShelvCore/Services/SubsonicResponseCompatibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/SubsonicResponseCompatibility.swift; sourceTree = "<group>"; };
 		BC1001532FFE000000000001 /* ShelvCore/Stores/SearchHistoryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Stores/SearchHistoryStore.swift; sourceTree = "<group>"; };
 		BC1001552FFE000000000001 /* ShelvCore/Support/AlphabetIndexSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Support/AlphabetIndexSelection.swift; sourceTree = "<group>"; };
+		AAF00507000000000000C0DE /* ShelvCore/Support/OpenSubsonicCapabilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Support/OpenSubsonicCapabilities.swift; sourceTree = "<group>"; };
 		BC1001612FFE000000000001 /* ShelvCore/Services/InfinityMixPoolBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/InfinityMixPoolBuilder.swift; sourceTree = "<group>"; };
 		BC2000012FFE000000000001 /* ShelvAppIntentsUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ShelvAppIntentsUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BC5116112FDC8A690011CDE9 /* Shelv TV.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Shelv TV.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -318,6 +320,7 @@
 				BC1001512FFE000000000001 /* ShelvCore/Services/SubsonicResponseCompatibility.swift */,
 				BC1001532FFE000000000001 /* ShelvCore/Stores/SearchHistoryStore.swift */,
 				BC1001552FFE000000000001 /* ShelvCore/Support/AlphabetIndexSelection.swift */,
+				AAF00507000000000000C0DE /* ShelvCore/Support/OpenSubsonicCapabilities.swift */,
 				BC10014D2FFE000000000001 /* ShelvCore/Stores/DownloadUIStateHub.swift */,
 			);
 			name = "ShelvCore Test Sources";
@@ -671,6 +674,7 @@
 				BC1001502FFE000000000001 /* ShelvCore/Services/SubsonicResponseCompatibility.swift in Sources */,
 				BC1001522FFE000000000001 /* ShelvCore/Stores/SearchHistoryStore.swift in Sources */,
 				BC1001542FFE000000000001 /* ShelvCore/Support/AlphabetIndexSelection.swift in Sources */,
+				BBF00507000000000000C0DE /* ShelvCore/Support/OpenSubsonicCapabilities.swift in Sources */,
 				BC10014C2FFE000000000001 /* ShelvCore/Stores/DownloadUIStateHub.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ShelvCore/Services/SubsonicAPIService.swift
+++ b/ShelvCore/Services/SubsonicAPIService.swift
@@ -191,7 +191,19 @@ private nonisolated struct PingInfoBody: Decodable, Sendable {
     let version: String
     let type: String?
     let serverVersion: String?
+    let openSubsonic: Bool?
     let error: StatusCheck.APIError?
+}
+
+private nonisolated struct OpenSubsonicExtensionsBody: Decodable, Sendable {
+    let status: String
+    let error: StatusCheck.APIError?
+    let openSubsonicExtensions: [Extension]?
+
+    struct Extension: Decodable, Sendable {
+        let name: String
+        let versions: [Int]?
+    }
 }
 
 private nonisolated struct GetUserBody: Decodable, Sendable {
@@ -453,6 +465,11 @@ nonisolated class SubsonicAPIService: ObservableObject, @unchecked Sendable {
 
     private let credentialLock = NSLock()
     private let compatibilityLock = NSLock()
+    private let capabilityLock = NSLock()
+    /// OpenSubsonic extensions per server, learned at connection time and kept
+    /// for the session only: a server that gets upgraded should be re-probed on
+    /// the next launch rather than remembered as it was months ago.
+    nonisolated(unsafe) private var _openSubsonicCapabilities: [String: OpenSubsonicCapabilities] = [:]
     nonisolated(unsafe) private var _activeServer: SubsonicServer?
     nonisolated(unsafe) private var _activePassword: String?
     nonisolated(unsafe) private var _credentialGeneration: UInt64 = 0
@@ -1285,7 +1302,85 @@ nonisolated class SubsonicAPIService: ObservableObject, @unchecked Sendable {
             responseFormatServerFingerprint(info),
             serverKey: responseFormatServerKey(for: server)
         )
+        // Connecting is the natural moment to learn what the server implements.
+        // A server that answers `openSubsonic: false`, or no flag at all, is a
+        // classic Subsonic server and must never be asked for an extension.
+        if body.openSubsonic == true {
+            await refreshOpenSubsonicCapabilities(server: server, password: password)
+        } else {
+            storeOpenSubsonicCapabilities(.none, for: server)
+        }
         return info
+    }
+
+    /// What the given server advertised through `getOpenSubsonicExtensions`.
+    ///
+    /// Returns `.none` until the server has been probed, which is deliberate:
+    /// an un-probed server must be treated as a classic Subsonic server rather
+    /// than optimistically called with extension-only parameters.
+    nonisolated func openSubsonicCapabilities(for server: SubsonicServer) -> OpenSubsonicCapabilities {
+        capabilityLock.withLock {
+            _openSubsonicCapabilities[responseFormatServerKey(for: server)] ?? .none
+        }
+    }
+
+    /// Capabilities of the server currently in use, probing it once if the app
+    /// has not connected through `ping(server:password:)` in this session.
+    func openSubsonicCapabilities() async -> OpenSubsonicCapabilities {
+        guard let credentials = try? await resolveCredentials() else { return .none }
+        let key = responseFormatServerKey(for: credentials.server)
+        if let known = capabilityLock.withLock({ _openSubsonicCapabilities[key] }) {
+            return known
+        }
+        await refreshOpenSubsonicCapabilities(
+            server: credentials.server,
+            password: credentials.password
+        )
+        return openSubsonicCapabilities(for: credentials.server)
+    }
+
+    /// Asks the server what it implements. Never throws: a server that does not
+    /// know the endpoint answers with an API error or a 404, and that is simply
+    /// the answer "nothing", not a failure worth surfacing to the listener.
+    private func refreshOpenSubsonicCapabilities(server: SubsonicServer, password: String) async {
+        let capabilities: OpenSubsonicCapabilities
+        do {
+            capabilities = try await getOpenSubsonicExtensions(server: server, password: password)
+        } catch {
+            capabilities = .none
+        }
+        storeOpenSubsonicCapabilities(capabilities, for: server)
+    }
+
+    nonisolated private func storeOpenSubsonicCapabilities(
+        _ capabilities: OpenSubsonicCapabilities,
+        for server: SubsonicServer
+    ) {
+        let key = responseFormatServerKey(for: server)
+        capabilityLock.withLock { _openSubsonicCapabilities[key] = capabilities }
+    }
+
+    func getOpenSubsonicExtensions(
+        server: SubsonicServer,
+        password: String
+    ) async throws -> OpenSubsonicCapabilities {
+        #if DEBUG
+        if server.baseURL == DemoContent.serverBaseURL || server.activeBaseURL == DemoContent.serverBaseURL {
+            return .none
+        }
+        #endif
+        let body = try await fetchDecoded(
+            Envelope<OpenSubsonicExtensionsBody>.self,
+            for: server,
+            password: password,
+            path: "getOpenSubsonicExtensions"
+        ).response
+        try check(status: body.status, error: body.error)
+        return OpenSubsonicCapabilities(
+            advertised: (body.openSubsonicExtensions ?? []).map {
+                (name: $0.name, versions: $0.versions ?? [1])
+            }
+        )
     }
 
     /// Whether the given credentials have admin rights on the server. Some operations

--- a/ShelvCore/Support/OpenSubsonicCapabilities.swift
+++ b/ShelvCore/Support/OpenSubsonicCapabilities.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// Names of the OpenSubsonic extensions Shelv knows how to take advantage of.
+///
+/// Servers advertise what they implement through `getOpenSubsonicExtensions`.
+/// Anything not advertised must not be called: classic Subsonic servers answer
+/// those endpoints with an error, and Navidrome returns 404 for an extension
+/// whose backing plugin is missing.
+nonisolated enum OpenSubsonicExtension {
+    /// Structured lyrics. Version 2 adds word and syllable timing behind `enhanced=true`.
+    static let songLyrics = "songLyrics"
+    /// Audio similarity: `getSonicSimilarTracks` and `findSonicPath`.
+    static let sonicSimilarity = "sonicSimilarity"
+    /// `getTopSongs` accepts an artist id rather than a name.
+    static let topSongsByArtistId = "topSongsByArtistId"
+    /// Credentials sent as an API key instead of an MD5 of salt and password.
+    static let apiKeyAuthentication = "apiKeyAuthentication"
+    /// Seeking inside a transcoded stream.
+    static let transcodeOffset = "transcodeOffset"
+    /// Credentials sent in a form body instead of the query string.
+    static let formPost = "formPost"
+}
+
+/// What one server advertised, with the versions it supports per extension.
+nonisolated struct OpenSubsonicCapabilities: Equatable, Sendable {
+    /// A server that advertised nothing, or was never asked. Supports nothing.
+    static let none = OpenSubsonicCapabilities(extensions: [:])
+
+    private let extensions: [String: Set<Int>]
+
+    init(extensions: [String: Set<Int>]) {
+        self.extensions = extensions
+    }
+
+    init(advertised: [(name: String, versions: [Int])]) {
+        // A server may repeat a name; merge rather than let the last one win.
+        self.extensions = advertised.reduce(into: [:]) { result, entry in
+            result[entry.name, default: []].formUnion(entry.versions)
+        }
+    }
+
+    /// True when the server implements `name` at `version` or better.
+    ///
+    /// Versions are independent numbers rather than a range, so a server that
+    /// advertises only version 2 still answers version 1 requests: the spec
+    /// requires later versions to stay backwards compatible.
+    func supports(_ name: String, version: Int = 1) -> Bool {
+        guard let versions = extensions[name] else { return false }
+        return versions.contains { $0 >= version }
+    }
+
+    var isEmpty: Bool { extensions.isEmpty }
+}

--- a/ShelvTests/OpenSubsonicCapabilitiesTests.swift
+++ b/ShelvTests/OpenSubsonicCapabilitiesTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+
+final class OpenSubsonicCapabilitiesTests: XCTestCase {
+    func testAServerThatWasNeverAskedSupportsNothing() {
+        XCTAssertFalse(OpenSubsonicCapabilities.none.supports(OpenSubsonicExtension.songLyrics))
+        XCTAssertTrue(OpenSubsonicCapabilities.none.isEmpty)
+    }
+
+    func testAdvertisedExtensionsAreMatchedByNameAndVersion() {
+        let caps = OpenSubsonicCapabilities(advertised: [
+            (name: OpenSubsonicExtension.songLyrics, versions: [1, 2]),
+            (name: OpenSubsonicExtension.transcodeOffset, versions: [1])
+        ])
+
+        XCTAssertTrue(caps.supports(OpenSubsonicExtension.songLyrics))
+        XCTAssertTrue(caps.supports(OpenSubsonicExtension.songLyrics, version: 2))
+        XCTAssertTrue(caps.supports(OpenSubsonicExtension.transcodeOffset))
+        XCTAssertFalse(caps.supports(OpenSubsonicExtension.transcodeOffset, version: 2))
+        XCTAssertFalse(caps.supports(OpenSubsonicExtension.sonicSimilarity))
+    }
+
+    func testALaterVersionSatisfiesAnEarlierRequirement() {
+        // The spec requires later versions to stay backwards compatible, so a
+        // server advertising only v2 still answers a v1 request.
+        let caps = OpenSubsonicCapabilities(advertised: [
+            (name: OpenSubsonicExtension.songLyrics, versions: [2])
+        ])
+
+        XCTAssertTrue(caps.supports(OpenSubsonicExtension.songLyrics, version: 1))
+        XCTAssertTrue(caps.supports(OpenSubsonicExtension.songLyrics, version: 2))
+        XCTAssertFalse(caps.supports(OpenSubsonicExtension.songLyrics, version: 3))
+    }
+
+    func testARepeatedNameMergesItsVersionsInsteadOfOverwriting() {
+        let caps = OpenSubsonicCapabilities(advertised: [
+            (name: OpenSubsonicExtension.songLyrics, versions: [1]),
+            (name: OpenSubsonicExtension.songLyrics, versions: [2])
+        ])
+
+        XCTAssertTrue(caps.supports(OpenSubsonicExtension.songLyrics, version: 2))
+    }
+}


### PR DESCRIPTION
`getOpenSubsonicExtensions` is not called anywhere. The only trace of OpenSubsonic in the app is the `openSubsonic` attribute in a compatibility test fixture, parsed but never acted on.

That is fine while Shelv only calls endpoints classic Subsonic servers also implement. It stops being fine as soon as any extension is wanted:

- `songLyrics` v2 — word and syllable timing behind `enhanced=true` (#10)
- `sonicSimilarity` — `getSonicSimilarTracks` and `findSonicPath`
- `apiKeyAuthentication` — instead of the MD5 of salt and password
- `transcodeOffset` — seeking inside a transcoded stream

None of these can be called optimistically. A classic Subsonic server answers with an API error, and Navidrome returns **HTTP 404** for an extension whose backing plugin is missing: `sonicSimilarity` is only advertised when a plugin such as AudioMuse-AI provides it.

## What this does

`ping(server:password:)` already runs when a server is added, edited or validated, and already receives the `openSubsonic` flag. It now reads that flag, and only when it is `true` asks what the server implements. A server answering `false`, or omitting the flag, is recorded as supporting nothing, so no extra request is ever made against a classic server.

`openSubsonicCapabilities()` probes lazily for the current server if the app has not connected in this session, and never throws: a 404 or an API error is the answer "nothing", not a failure worth showing a listener.

Nothing is persisted. An upgraded server is re-probed on the next launch instead of being remembered as it was months ago.

`supports(_:version:)` treats versions as independent numbers, so a server advertising only v2 satisfies a v1 requirement — the spec requires later versions to stay backwards compatible.

## Shape

Pure logic and 4 tests in `ShelvCore/Support/OpenSubsonicCapabilities.swift`, following `ArtistTopSongsRanking`. Networking stays in `SubsonicAPIService`. No UI change, no behaviour change on any existing server: this PR only makes the app *aware*.

Happy to fold it into whichever extension you want first, if you would rather not merge plumbing on its own. `feat/enhanced-lyrics` builds directly on it.

## Verification

Rebased on `main` at 008bad1, linear: one feature commit plus a one-line `project.pbxproj` move so this branch and my other open ones stop fighting over the same spot in the test target.

Green on all three targets: 467 tests on iOS 26.5 (iPhone 17 Pro), 470 on macOS, no failures, 4 of them new in `OpenSubsonicCapabilitiesTests`. `Shelv TV` builds against the tvOS 26.5 simulator, which #46 made possible again.

