### PR TITLE
fix: stop the artist page asserting album types it only guessed

### DIFF
--- a/Shelv Mac/Views/ArtistDetailView.swift
+++ b/Shelv Mac/Views/ArtistDetailView.swift
@@ -76,12 +76,13 @@ struct ArtistDetailView: View {
         searchQuery.isEmpty ? ArtistDiscography.availableGroups(for: availableAlbums) : []
     }
 
-    private var albumsOnly: [Album] {
-        ArtistDiscography.filter(displayAlbums, to: .albums)
-    }
-
-    private var shortReleases: [Album] {
-        ArtistDiscography.filter(displayAlbums, to: .singlesAndEPs)
+    /// Albums and short releases on their own shelves, or one shelf for the
+    /// whole discography when splitting would say nothing about it.
+    private var shelves: [(group: ArtistReleaseGroup, albums: [Album])] {
+        ArtistDiscography.shelfGroups(for: displayAlbums).compactMap { group in
+            let albums = ArtistDiscography.filter(displayAlbums, to: group)
+            return albums.isEmpty ? nil : (group, albums)
+        }
     }
 
     private var latestRelease: Album? {
@@ -245,16 +246,10 @@ struct ArtistDetailView: View {
 
                             if isGrid && searchQuery.isEmpty {
                                 VStack(alignment: .leading, spacing: 24) {
-                                    if !albumsOnly.isEmpty {
+                                    ForEach(shelves, id: \.group.rawValue) { shelf in
                                         ArtistReleaseShelf(
-                                            title: String(localized: "albums"),
-                                            albums: albumsOnly
-                                        )
-                                    }
-                                    if !shortReleases.isEmpty {
-                                        ArtistReleaseShelf(
-                                            title: String(localized: "release_group_singles_eps"),
-                                            albums: shortReleases
+                                            title: shelf.group.shelfTitle,
+                                            albums: shelf.albums
                                         )
                                     }
                                 }

--- a/Shelv Mac/Views/ArtistPageSections.swift
+++ b/Shelv Mac/Views/ArtistPageSections.swift
@@ -9,6 +9,13 @@ extension ArtistReleaseGroup {
         case .singlesAndEPs: String(localized: "release_group_singles_eps")
         }
     }
+
+    /// Title of a grid shelf, or `nil` when the page has already titled it.
+    /// `.all` is the whole discography on one shelf, which is exactly what the
+    /// standing "Discography" heading above it says.
+    var shelfTitle: String? {
+        self == .all ? nil : label
+    }
 }
 
 /// Identifies the full, sortable album list behind a release shelf's title:
@@ -23,25 +30,31 @@ struct ArtistAlbumGroup: Hashable {
 /// sortable list, with the same grid/list and sort options as the Library's
 /// own Albums screen.
 struct ArtistReleaseShelf: View {
-    let title: String
+    /// `nil` drops the header row, and with it the link to the full list. A
+    /// shelf the page has already titled holds every release the artist has,
+    /// and the sort and grid/list controls right above it do what that list
+    /// would have offered.
+    let title: String?
     let albums: [Album]
 
     private let itemWidth: CGFloat = 170
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            NavigationLink(value: ArtistAlbumGroup(title: title, albums: albums)) {
-                HStack(spacing: 4) {
-                    Text(title)
-                        .font(.title3.bold())
-                        .foregroundStyle(.primary)
-                    Image(systemName: "chevron.right")
-                        .font(.subheadline.bold())
-                        .foregroundStyle(.secondary)
+            if let title {
+                NavigationLink(value: ArtistAlbumGroup(title: title, albums: albums)) {
+                    HStack(spacing: 4) {
+                        Text(title)
+                            .font(.title3.bold())
+                            .foregroundStyle(.primary)
+                        Image(systemName: "chevron.right")
+                            .font(.subheadline.bold())
+                            .foregroundStyle(.secondary)
+                    }
                 }
+                .buttonStyle(.plain)
+                .padding(.horizontal, 24)
             }
-            .buttonStyle(.plain)
-            .padding(.horizontal, 24)
 
             ScrollView(.horizontal) {
                 LazyHStack(alignment: .top, spacing: 16) {

--- a/Shelv/Views/Library/ArtistDetailView.swift
+++ b/Shelv/Views/Library/ArtistDetailView.swift
@@ -96,12 +96,13 @@ struct ArtistDetailView: View {
         searchQuery.isEmpty ? ArtistDiscography.availableGroups(for: sortedAlbums) : []
     }
 
-    private var albumsOnly: [Album] {
-        ArtistDiscography.filter(sortedAlbums, to: .albums)
-    }
-
-    private var shortReleases: [Album] {
-        ArtistDiscography.filter(sortedAlbums, to: .singlesAndEPs)
+    /// Albums and short releases on their own shelves, or one shelf for the
+    /// whole discography when splitting would say nothing about it.
+    private var shelves: [(group: ArtistReleaseGroup, albums: [Album])] {
+        ArtistDiscography.shelfGroups(for: sortedAlbums).compactMap { group in
+            let albums = ArtistDiscography.filter(sortedAlbums, to: group)
+            return albums.isEmpty ? nil : (group, albums)
+        }
     }
 
     /// Newest by release year, then by the date the server first saw it.
@@ -430,35 +431,22 @@ struct ArtistDetailView: View {
                     }
                 }
 
-                if !albumsOnly.isEmpty {
+                ForEach(Array(shelves.enumerated()), id: \.element.group.rawValue) { index, shelf in
                     Section {
                         ArtistReleaseShelf(
-                            title: String(localized: "albums"),
-                            albums: albumsOnly,
+                            title: shelf.group.shelfTitle,
+                            albums: shelf.albums,
                             personalization: personalization,
                             sortRaw: $sortRaw,
                             directionRaw: $directionRaw,
                             isOffline: offlineMode.isOffline,
                             accentColor: accentColor
                         )
-                        .listRowInsets(EdgeInsets(top: 16, leading: 0, bottom: 0, trailing: 0))
-                        .listRowBackground(Color.clear)
-                        .listRowSeparator(.hidden)
-                    }
-                }
-
-                if !shortReleases.isEmpty {
-                    Section {
-                        ArtistReleaseShelf(
-                            title: String(localized: "release_group_singles_eps"),
-                            albums: shortReleases,
-                            personalization: personalization,
-                            sortRaw: $sortRaw,
-                            directionRaw: $directionRaw,
-                            isOffline: offlineMode.isOffline,
-                            accentColor: accentColor
+                        .listRowInsets(
+                            index == 0
+                                ? EdgeInsets(top: 16, leading: 0, bottom: 0, trailing: 0)
+                                : EdgeInsets()
                         )
-                        .listRowInsets(EdgeInsets())
                         .listRowBackground(Color.clear)
                         .listRowSeparator(.hidden)
                     }

--- a/Shelv/Views/Library/ArtistPageSections.swift
+++ b/Shelv/Views/Library/ArtistPageSections.swift
@@ -9,6 +9,12 @@ extension ArtistReleaseGroup {
         case .singlesAndEPs: String(localized: "release_group_singles_eps")
         }
     }
+
+    /// Title of a grid shelf. `.all` carries the whole discography there, so it
+    /// takes the discography heading rather than the picker's "All".
+    var shelfTitle: String {
+        self == .all ? String(localized: "discography") : label
+    }
 }
 
 /// Album / singles filter of the discography section. Only shown when the

--- a/ShelvCore/Services/ArtistDiscography.swift
+++ b/ShelvCore/Services/ArtistDiscography.swift
@@ -54,6 +54,25 @@ nonisolated enum ArtistDiscography {
         return albums.filter { self.group(for: $0) == group }
     }
 
+    /// The shelves the grid layouts render, in order.
+    ///
+    /// Splitting says something only when the artist has both kinds of
+    /// release. With one kind, one shelf carries the whole discography, and
+    /// naming it depends on where the answer came from: a server that declared
+    /// `releaseTypes` can be quoted, a track-count guess cannot. A library that
+    /// holds a single downloaded track of an album looks exactly like a pile of
+    /// singles, and shelving it under "Singles & EPs" leaves the albums shelf
+    /// empty on an artist whose albums the listener owns.
+    static func shelfGroups(for albums: [Album]) -> [ArtistReleaseGroup] {
+        guard let first = albums.first else { return [] }
+        guard availableGroups(for: albums).isEmpty else { return [.albums, .singlesAndEPs] }
+
+        let onlyGroup = group(for: first)
+        let serverStayedSilent = albums.allSatisfy { declaredGroup(for: $0) == nil }
+        if onlyGroup == .singlesAndEPs, serverStayedSilent { return [.all] }
+        return [onlyGroup]
+    }
+
     /// The filter is only worth showing when the artist actually has both kinds
     /// of release. One button that filters nothing is noise.
     static func availableGroups(for albums: [Album]) -> [ArtistReleaseGroup] {

--- a/ShelvTests/ArtistDiscographyTests.swift
+++ b/ShelvTests/ArtistDiscographyTests.swift
@@ -60,4 +60,49 @@ final class ArtistDiscographyTests: XCTestCase {
         XCTAssertTrue(ArtistDiscography.availableGroups(for: []).isEmpty)
         XCTAssertEqual(ArtistDiscography.availableGroups(for: mixed), ArtistReleaseGroup.allCases)
     }
+
+    // MARK: - Shelves
+
+    func testTwoShelvesWhenTheArtistHasBothKindsOfRelease() {
+        let albums = [
+            album(id: "1", songCount: 12, duration: 3_000),
+            album(id: "2", songCount: 1, duration: 240)
+        ]
+
+        XCTAssertEqual(ArtistDiscography.shelfGroups(for: albums), [.albums, .singlesAndEPs])
+    }
+
+    /// A library holding one downloaded track of an album looks exactly like a
+    /// pile of singles. Naming the shelf "Singles & EPs" then asserts something
+    /// the server never said, and leaves the albums shelf empty.
+    func testOneNeutralShelfWhenEveryShortReleaseWasGuessed() {
+        let albums = [
+            album(id: "1", songCount: 1, duration: 240),
+            album(id: "2", songCount: 2, duration: 420)
+        ]
+
+        XCTAssertEqual(ArtistDiscography.shelfGroups(for: albums), [.all])
+    }
+
+    func testOneSinglesShelfWhenTheServerDeclaredThem() {
+        let albums = [
+            album(id: "1", songCount: 1, duration: 240, releaseTypes: ["single"]),
+            album(id: "2", songCount: 2, duration: 420)
+        ]
+
+        XCTAssertEqual(ArtistDiscography.shelfGroups(for: albums), [.singlesAndEPs])
+    }
+
+    func testOneAlbumsShelfWhenEveryReleaseIsAnAlbum() {
+        let albums = [
+            album(id: "1", songCount: 12, duration: 3_000),
+            album(id: "2", songCount: 1, duration: 240, releaseTypes: ["album"])
+        ]
+
+        XCTAssertEqual(ArtistDiscography.shelfGroups(for: albums), [.albums])
+    }
+
+    func testNoShelfWithoutReleases() {
+        XCTAssertEqual(ArtistDiscography.shelfGroups(for: []), [])
+    }
 }


### PR DESCRIPTION
Testing 1.5 against my own Navidrome (0.63.2) turned up a case where the artist page shows less than the listener owns. It comes from the discography split I contributed in #35, so this is mine to clean up.

## Inferred "single" swallows the discography

`ArtistDiscography` falls back to track count when the server sends no `releaseTypes`. That is right for a complete library and wrong for a partial one: three tracks of an album look exactly like a single.

Measured over my whole library, 3122 albums:

| | |
|---|---|
| albums with a single track | 2505 (80 %) |
| albums with 3 tracks or fewer | 2751 (88 %) |
| no `releaseTypes` from the server | 727 (23 %) |

Per artist, the visible result:

| artist | Albums shelf | Singles & EPs shelf |
|---|---|---|
| Stromae | **0** | 1 |
| Hatik | 4 | 10 |

The grid now splits in two only when both release types are really present. With one inferred type it puts the whole discography on one shelf instead of asserting "Singles and EPs". 307 artists out of 1746 change; nothing is hidden or reordered.

## The duplicate heading

Fixed on the shelf side rather than the heading side. On macOS that single shelf now renders without a title of its own, so the standing heading (`Shelv Mac/Views/ArtistDetailView.swift:193` after the rebase) stays the only "Discography" on the page.

That costs the shelf title's link into `ArtistAllAlbumsView`, and I think it is the right thing to lose here: the shelf already holds every release the artist has, and the sort menu and grid/list toggle sitting directly above it do what that screen offers. `ArtistReleaseShelf.title` is `String?` on the Mac target now, `nil` meaning "the page has already titled me". iOS has no standing heading, so its shelf keeps the title.

## Downloads notice

Out of here, now #47, based on `main` and independent of this branch. The two merge cleanly with each other, so either order works.

## Verification

Rebased on `main` at 82523aa, so on top of #43 as you asked. Both targets build and the suite is green on both: 468 tests on iOS 26.5 (iPhone 17 Pro), 472 on macOS, no failures. 13 in `ArtistDiscographyTests`, 5 of them new.

## Flaky test

The `testIdenticalFallbackRequestsAreCoalesced()` race is #45, as you noted.
