### PR TITLE
feat: tap the artist photo to see it full size

### DIFF
--- a/Shelv Mac/Views/ArtistDetailView.swift
+++ b/Shelv Mac/Views/ArtistDetailView.swift
@@ -34,6 +34,7 @@ struct ArtistDetailView: View {
     @State private var isLoadingSearchSongs = false
     @State private var loadedSongSearchSourceID: String?
     @State private var topSongsFirstVisible = 0
+    @State private var isShowingArtwork = false
 
     private var effectiveShowDownloadsOnly: Bool {
         offlineMode.isOffline || showDownloadsOnly
@@ -143,8 +144,22 @@ struct ArtistDetailView: View {
                 ScrollView {
                     VStack(alignment: .leading, spacing: 24) {
                         HStack(alignment: .top, spacing: 24) {
-                            CoverArtView(url: coverURL, size: 120, isCircle: true)
-                                .shadow(color: .black.opacity(0.2), radius: 10)
+                            Button {
+                                isShowingArtwork = true
+                            } label: {
+                                CoverArtView(url: coverURL, size: 120, isCircle: true)
+                                    .shadow(color: .black.opacity(0.2), radius: 10)
+                            }
+                            .buttonStyle(.plain)
+                            .disabled(vm.artist?.coverArt == nil)
+                            .help(String(localized: "artwork_open"))
+                            .accessibilityLabel(String(localized: "artwork_open"))
+                            .sheet(isPresented: $isShowingArtwork) {
+                                ArtworkViewerView(
+                                    coverArtId: vm.artist?.coverArt,
+                                    title: vm.artist?.name ?? artistName
+                                )
+                            }
 
                             VStack(alignment: .leading, spacing: 8) {
                                 Text(vm.artist?.name ?? artistName)

--- a/Shelv Mac/Views/ArtworkViewerView.swift
+++ b/Shelv Mac/Views/ArtworkViewerView.swift
@@ -1,0 +1,77 @@
+import SwiftUI
+
+/// Full-size artwork, opened by clicking a cover or an artist photo.
+///
+/// Loading goes through `CoverArtView` so the viewer inherits the memory and disk
+/// cache, the retry policy and the offline fallback rather than fetching its own copy.
+struct ArtworkViewerView: View {
+    let coverArtId: String?
+    let title: String
+
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var scale: CGFloat = ArtworkZoomGeometry.minScale
+    @State private var offset: CGSize = .zero
+    @State private var gestureOffset: CGSize = .zero
+
+    private static let side: CGFloat = 640
+
+    private var viewport: CGSize { CGSize(width: Self.side, height: Self.side) }
+
+    private var liveOffset: CGSize {
+        ArtworkZoomGeometry.clampOffset(
+            CGSize(
+                width: offset.width + gestureOffset.width,
+                height: offset.height + gestureOffset.height
+            ),
+            scale: scale,
+            viewport: viewport
+        )
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            CoverArtView(
+                coverArtID: coverArtId,
+                requestSize: 1000,
+                size: Self.side,
+                cornerRadius: 0
+            )
+            .scaleEffect(scale)
+            .offset(liveOffset)
+            .frame(width: Self.side, height: Self.side)
+            .clipped()
+            .contentShape(Rectangle())
+            .gesture(pan)
+            .onTapGesture(count: 2) { toggleZoom() }
+            .accessibilityLabel(title)
+
+            HStack {
+                Spacer()
+                Button(String(localized: "done")) { dismiss() }
+                    .keyboardShortcut(.cancelAction)
+            }
+            .padding(12)
+        }
+        .background(Color.black)
+    }
+
+    private var pan: some Gesture {
+        DragGesture()
+            .onChanged { value in
+                guard scale > ArtworkZoomGeometry.minScale else { return }
+                gestureOffset = value.translation
+            }
+            .onEnded { _ in
+                offset = liveOffset
+                gestureOffset = .zero
+            }
+    }
+
+    private func toggleZoom() {
+        withAnimation(.snappy(duration: 0.25)) {
+            scale = ArtworkZoomGeometry.scaleAfterDoubleTap(current: scale)
+            offset = ArtworkZoomGeometry.clampOffset(.zero, scale: scale, viewport: viewport)
+        }
+    }
+}

--- a/Shelv Mac/de.lproj/Localizable.strings
+++ b/Shelv Mac/de.lproj/Localizable.strings
@@ -778,3 +778,4 @@
 "share" = "Teilen";
 "share_link_failed" = "Link konnte nicht erstellt werden.";
 "error" = "Fehler";
+"artwork_open" = "Bild vergrößern";

--- a/Shelv Mac/en.lproj/Localizable.strings
+++ b/Shelv Mac/en.lproj/Localizable.strings
@@ -778,3 +778,4 @@
 "share" = "Share";
 "share_link_failed" = "Couldn't create share link.";
 "error" = "Error";
+"artwork_open" = "Enlarge image";

--- a/Shelv Mac/fr.lproj/Localizable.strings
+++ b/Shelv Mac/fr.lproj/Localizable.strings
@@ -778,3 +778,4 @@
 "share" = "Partager";
 "share_link_failed" = "Impossible de créer le lien de partage.";
 "error" = "Erreur";
+"artwork_open" = "Agrandir l’image";

--- a/Shelv Mac/zh-Hans.lproj/Localizable.strings
+++ b/Shelv Mac/zh-Hans.lproj/Localizable.strings
@@ -778,3 +778,4 @@
 "share" = "分享";
 "share_link_failed" = "无法创建分享链接。";
 "error" = "错误";
+"artwork_open" = "放大图片";

--- a/Shelv.xcodeproj/project.pbxproj
+++ b/Shelv.xcodeproj/project.pbxproj
@@ -55,7 +55,6 @@
 		BC1001502FFE000000000001 /* ShelvCore/Services/SubsonicResponseCompatibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1001512FFE000000000001 /* ShelvCore/Services/SubsonicResponseCompatibility.swift */; };
 		BC1001522FFE000000000001 /* ShelvCore/Stores/SearchHistoryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1001532FFE000000000001 /* ShelvCore/Stores/SearchHistoryStore.swift */; };
 		BC1001542FFE000000000001 /* ShelvCore/Support/AlphabetIndexSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1001552FFE000000000001 /* ShelvCore/Support/AlphabetIndexSelection.swift */; };
-		BBF0B00D0000000000000000 /* ShelvCore/Support/ArtworkZoomGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF0B00D0000000000000000 /* ShelvCore/Support/ArtworkZoomGeometry.swift */; };
 		BC1001602FFE000000000001 /* ShelvCore/Services/InfinityMixPoolBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1001612FFE000000000001 /* ShelvCore/Services/InfinityMixPoolBuilder.swift */; };
 		BC1867E52F91A088006D96E2 /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = BC1867E42F91A088006D96E2 /* GRDB */; };
 		BC51161D2FDC8A850011CDE9 /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = BC51161C2FDC8A850011CDE9 /* GRDB */; };
@@ -63,6 +62,7 @@
 		BC7B84A72FDB17F90058CB78 /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = BC7B84A62FDB17F90058CB78 /* GRDB */; };
 		BDDE62632EE3EF6E00895502 /* ShelvCore/Services/RecapExpectedSongsLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = D602F58338426465B1E367C5 /* ShelvCore/Services/RecapExpectedSongsLogic.swift */; };
 		D65A40B16B924F709F912515 /* ShelvCore/Services/ConcurrencyLimiter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB776033CC96417A93CA66DB /* ShelvCore/Services/ConcurrencyLimiter.swift */; };
+		BBF0B00D0000000000000000 /* ShelvCore/Support/ArtworkZoomGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF0B00D0000000000000000 /* ShelvCore/Support/ArtworkZoomGeometry.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -141,7 +141,6 @@
 		BC1001512FFE000000000001 /* ShelvCore/Services/SubsonicResponseCompatibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/SubsonicResponseCompatibility.swift; sourceTree = "<group>"; };
 		BC1001532FFE000000000001 /* ShelvCore/Stores/SearchHistoryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Stores/SearchHistoryStore.swift; sourceTree = "<group>"; };
 		BC1001552FFE000000000001 /* ShelvCore/Support/AlphabetIndexSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Support/AlphabetIndexSelection.swift; sourceTree = "<group>"; };
-		AAF0B00D0000000000000000 /* ShelvCore/Support/ArtworkZoomGeometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Support/ArtworkZoomGeometry.swift; sourceTree = "<group>"; };
 		BC1001612FFE000000000001 /* ShelvCore/Services/InfinityMixPoolBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/InfinityMixPoolBuilder.swift; sourceTree = "<group>"; };
 		BC2000012FFE000000000001 /* ShelvAppIntentsUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ShelvAppIntentsUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BC5116112FDC8A690011CDE9 /* Shelv TV.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Shelv TV.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -152,6 +151,7 @@
 		D602F58338426465B1E367C5 /* ShelvCore/Services/RecapExpectedSongsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/RecapExpectedSongsLogic.swift; sourceTree = "<group>"; };
 		D76D0722C024A55F5646646B /* ShelvCore/Services/RemoteStreamFailureRetryPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/RemoteStreamFailureRetryPolicy.swift; sourceTree = "<group>"; };
 		DB776033CC96417A93CA66DB /* ShelvCore/Services/ConcurrencyLimiter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/ConcurrencyLimiter.swift; sourceTree = "<group>"; };
+		AAF0B00D0000000000000000 /* ShelvCore/Support/ArtworkZoomGeometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Support/ArtworkZoomGeometry.swift; sourceTree = "<group>"; };
 		F2D3956FCB8E5BA0EA7B365B /* ShelvCore/Services/ArtistTopSongsRanking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/ArtistTopSongsRanking.swift; sourceTree = "<group>"; };
 		FFBB0EAEC930A6AA93845AF6 /* ShelvCore/Services/ArtistDiscography.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/ArtistDiscography.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -280,6 +280,7 @@
 				FFBB0EAEC930A6AA93845AF6 /* ShelvCore/Services/ArtistDiscography.swift */,
 				F2D3956FCB8E5BA0EA7B365B /* ShelvCore/Services/ArtistTopSongsRanking.swift */,
 				DB776033CC96417A93CA66DB /* ShelvCore/Services/ConcurrencyLimiter.swift */,
+				AAF0B00D0000000000000000 /* ShelvCore/Support/ArtworkZoomGeometry.swift */,
 				BC10012D2FFE000000000001 /* ShelvCore/Models/DownloadModels.swift */,
 				BC10013D2FFE000000000001 /* ShelvCore/Models/ShortcutPlaybackModels.swift */,
 				BC10013F2FFE000000000001 /* ShelvCore/Services/PlaybackContentResolver.swift */,
@@ -314,7 +315,6 @@
 				BC1001512FFE000000000001 /* ShelvCore/Services/SubsonicResponseCompatibility.swift */,
 				BC1001532FFE000000000001 /* ShelvCore/Stores/SearchHistoryStore.swift */,
 				BC1001552FFE000000000001 /* ShelvCore/Support/AlphabetIndexSelection.swift */,
-				AAF0B00D0000000000000000 /* ShelvCore/Support/ArtworkZoomGeometry.swift */,
 				BC10014D2FFE000000000001 /* ShelvCore/Stores/DownloadUIStateHub.swift */,
 			);
 			name = "ShelvCore Test Sources";
@@ -632,6 +632,7 @@
 				A3BC3F4796D89CE06D73AEBA /* ShelvCore/Services/ArtistDiscography.swift in Sources */,
 				4C9CE80450C542811BFC06B9 /* ShelvCore/Services/ArtistTopSongsRanking.swift in Sources */,
 				D65A40B16B924F709F912515 /* ShelvCore/Services/ConcurrencyLimiter.swift in Sources */,
+				BBF0B00D0000000000000000 /* ShelvCore/Support/ArtworkZoomGeometry.swift in Sources */,
 				BC10012C2FFE000000000001 /* ShelvCore/Models/DownloadModels.swift in Sources */,
 				BC10013C2FFE000000000001 /* ShelvCore/Models/ShortcutPlaybackModels.swift in Sources */,
 				BC10013E2FFE000000000001 /* ShelvCore/Services/PlaybackContentResolver.swift in Sources */,
@@ -666,7 +667,6 @@
 				BC1001502FFE000000000001 /* ShelvCore/Services/SubsonicResponseCompatibility.swift in Sources */,
 				BC1001522FFE000000000001 /* ShelvCore/Stores/SearchHistoryStore.swift in Sources */,
 				BC1001542FFE000000000001 /* ShelvCore/Support/AlphabetIndexSelection.swift in Sources */,
-				BBF0B00D0000000000000000 /* ShelvCore/Support/ArtworkZoomGeometry.swift in Sources */,
 				BC10014C2FFE000000000001 /* ShelvCore/Stores/DownloadUIStateHub.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Shelv.xcodeproj/project.pbxproj
+++ b/Shelv.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		BC1001502FFE000000000001 /* ShelvCore/Services/SubsonicResponseCompatibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1001512FFE000000000001 /* ShelvCore/Services/SubsonicResponseCompatibility.swift */; };
 		BC1001522FFE000000000001 /* ShelvCore/Stores/SearchHistoryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1001532FFE000000000001 /* ShelvCore/Stores/SearchHistoryStore.swift */; };
 		BC1001542FFE000000000001 /* ShelvCore/Support/AlphabetIndexSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1001552FFE000000000001 /* ShelvCore/Support/AlphabetIndexSelection.swift */; };
+		BBF0B00D0000000000000000 /* ShelvCore/Support/ArtworkZoomGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF0B00D0000000000000000 /* ShelvCore/Support/ArtworkZoomGeometry.swift */; };
 		BC1001602FFE000000000001 /* ShelvCore/Services/InfinityMixPoolBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1001612FFE000000000001 /* ShelvCore/Services/InfinityMixPoolBuilder.swift */; };
 		BC1867E52F91A088006D96E2 /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = BC1867E42F91A088006D96E2 /* GRDB */; };
 		BC51161D2FDC8A850011CDE9 /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = BC51161C2FDC8A850011CDE9 /* GRDB */; };
@@ -140,6 +141,7 @@
 		BC1001512FFE000000000001 /* ShelvCore/Services/SubsonicResponseCompatibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/SubsonicResponseCompatibility.swift; sourceTree = "<group>"; };
 		BC1001532FFE000000000001 /* ShelvCore/Stores/SearchHistoryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Stores/SearchHistoryStore.swift; sourceTree = "<group>"; };
 		BC1001552FFE000000000001 /* ShelvCore/Support/AlphabetIndexSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Support/AlphabetIndexSelection.swift; sourceTree = "<group>"; };
+		AAF0B00D0000000000000000 /* ShelvCore/Support/ArtworkZoomGeometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Support/ArtworkZoomGeometry.swift; sourceTree = "<group>"; };
 		BC1001612FFE000000000001 /* ShelvCore/Services/InfinityMixPoolBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/InfinityMixPoolBuilder.swift; sourceTree = "<group>"; };
 		BC2000012FFE000000000001 /* ShelvAppIntentsUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ShelvAppIntentsUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BC5116112FDC8A690011CDE9 /* Shelv TV.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Shelv TV.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -312,6 +314,7 @@
 				BC1001512FFE000000000001 /* ShelvCore/Services/SubsonicResponseCompatibility.swift */,
 				BC1001532FFE000000000001 /* ShelvCore/Stores/SearchHistoryStore.swift */,
 				BC1001552FFE000000000001 /* ShelvCore/Support/AlphabetIndexSelection.swift */,
+				AAF0B00D0000000000000000 /* ShelvCore/Support/ArtworkZoomGeometry.swift */,
 				BC10014D2FFE000000000001 /* ShelvCore/Stores/DownloadUIStateHub.swift */,
 			);
 			name = "ShelvCore Test Sources";
@@ -663,6 +666,7 @@
 				BC1001502FFE000000000001 /* ShelvCore/Services/SubsonicResponseCompatibility.swift in Sources */,
 				BC1001522FFE000000000001 /* ShelvCore/Stores/SearchHistoryStore.swift in Sources */,
 				BC1001542FFE000000000001 /* ShelvCore/Support/AlphabetIndexSelection.swift in Sources */,
+				BBF0B00D0000000000000000 /* ShelvCore/Support/ArtworkZoomGeometry.swift in Sources */,
 				BC10014C2FFE000000000001 /* ShelvCore/Stores/DownloadUIStateHub.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Shelv/Views/Library/ArtistDetailView.swift
+++ b/Shelv/Views/Library/ArtistDetailView.swift
@@ -41,6 +41,7 @@ struct ArtistDetailView: View {
     @State private var downloadedAlbumCounts: [String: Int] = [:]
     @State private var shareURL: IdentifiableURL?
     @State private var songPlaylistIds: SongPlaylistIds?
+    @State private var isShowingArtwork = false
 
     private var sortOption: AlbumSortOption {
         AlbumSortOption(rawValue: sortRaw) ?? .newest
@@ -184,6 +185,9 @@ struct ArtistDetailView: View {
             }
         }
         .shelveToast($currentToast)
+        .fullScreenCover(isPresented: $isShowingArtwork) {
+            ArtworkViewerView(coverArtId: artist.coverArt, title: artist.name)
+        }
         .sheet(item: $shareURL) { wrapped in
             ActivityShareSheet(items: [wrapped.url])
         }
@@ -256,8 +260,15 @@ struct ArtistDetailView: View {
     private var artistHeader: some View {
         VStack(alignment: .leading, spacing: 16) {
             HStack(spacing: 16) {
-                AlbumArtView(coverArtId: artist.coverArt, size: 300, isCircle: true)
-                    .frame(width: 100, height: 100)
+                Button {
+                    isShowingArtwork = true
+                } label: {
+                    AlbumArtView(coverArtId: artist.coverArt, size: 300, isCircle: true)
+                        .frame(width: 100, height: 100)
+                }
+                .buttonStyle(.plain)
+                .disabled(artist.coverArt == nil)
+                .accessibilityLabel(String(localized: "artwork_open"))
                 VStack(alignment: .leading, spacing: 4) {
                     Text(artist.name)
                         .font(.title2).bold()

--- a/Shelv/Views/Shared/ArtworkViewerView.swift
+++ b/Shelv/Views/Shared/ArtworkViewerView.swift
@@ -1,0 +1,115 @@
+import SwiftUI
+
+/// Full-screen artwork, opened by tapping a cover or an artist photo.
+///
+/// Loading goes through `AlbumArtView` so the viewer inherits the memory and disk
+/// cache, the retry policy and the offline fallback rather than fetching its own copy.
+struct ArtworkViewerView: View {
+    let coverArtId: String?
+    let title: String
+
+    @Environment(\.dismiss) private var dismiss
+
+    /// Committed after each gesture; the in-flight gesture value is layered on top.
+    @State private var scale: CGFloat = ArtworkZoomGeometry.minScale
+    @State private var gestureScale: CGFloat = 1
+    @State private var offset: CGSize = .zero
+    @State private var gestureOffset: CGSize = .zero
+    @State private var viewport: CGSize = .zero
+
+    private var liveScale: CGFloat {
+        ArtworkZoomGeometry.clampScale(scale * gestureScale)
+    }
+
+    private var liveOffset: CGSize {
+        ArtworkZoomGeometry.clampOffset(
+            CGSize(
+                width: offset.width + gestureOffset.width,
+                height: offset.height + gestureOffset.height
+            ),
+            scale: liveScale,
+            viewport: viewport
+        )
+    }
+
+    var body: some View {
+        GeometryReader { proxy in
+            ZStack {
+                Color.black.ignoresSafeArea()
+
+                AlbumArtView(coverArtId: coverArtId, size: 1000, cornerRadius: 0)
+                    .frame(
+                        width: min(proxy.size.width, proxy.size.height),
+                        height: min(proxy.size.width, proxy.size.height)
+                    )
+                    .scaleEffect(liveScale)
+                    .offset(liveOffset)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .contentShape(Rectangle())
+                    .gesture(magnification)
+                    .simultaneousGesture(pan)
+                    .onTapGesture(count: 2) { toggleZoom() }
+            }
+            .onAppear { viewport = proxy.size }
+            .onChange(of: proxy.size) { _, newValue in
+                viewport = newValue
+                offset = ArtworkZoomGeometry.clampOffset(offset, scale: scale, viewport: newValue)
+            }
+        }
+        .statusBarHidden()
+        .overlay(alignment: .topTrailing) { closeButton }
+        .accessibilityLabel(title)
+    }
+
+    private var closeButton: some View {
+        Button {
+            dismiss()
+        } label: {
+            Image(systemName: "xmark")
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(.white)
+                .padding(10)
+                .background(.ultraThinMaterial, in: Circle())
+        }
+        .padding(.top, 8)
+        .padding(.trailing, 16)
+        .accessibilityLabel(String(localized: "done"))
+    }
+
+    private var magnification: some Gesture {
+        MagnifyGesture()
+            .onChanged { gestureScale = $0.magnification }
+            .onEnded { _ in
+                scale = liveScale
+                offset = liveOffset
+                gestureScale = 1
+            }
+    }
+
+    private var pan: some Gesture {
+        DragGesture()
+            .onChanged { value in
+                // While the artwork fits, a drag is a dismiss gesture, not a pan.
+                guard scale > ArtworkZoomGeometry.minScale else { return }
+                gestureOffset = value.translation
+            }
+            .onEnded { value in
+                if ArtworkZoomGeometry.shouldDismiss(
+                    verticalDrag: value.translation.height,
+                    scale: scale
+                ) {
+                    dismiss()
+                    return
+                }
+                offset = liveOffset
+                gestureOffset = .zero
+            }
+    }
+
+    private func toggleZoom() {
+        withAnimation(.snappy(duration: 0.25)) {
+            scale = ArtworkZoomGeometry.scaleAfterDoubleTap(current: scale)
+            offset = ArtworkZoomGeometry.clampOffset(.zero, scale: scale, viewport: viewport)
+        }
+    }
+}

--- a/Shelv/de.lproj/Localizable.strings
+++ b/Shelv/de.lproj/Localizable.strings
@@ -778,3 +778,4 @@
 "shortcut_play_or_shuffle_dialog" = "Abspielen oder mischen?";
 "share" = "Teilen";
 "share_link_failed" = "Link konnte nicht erstellt werden.";
+"artwork_open" = "Bild vergrößern";

--- a/Shelv/en.lproj/Localizable.strings
+++ b/Shelv/en.lproj/Localizable.strings
@@ -778,3 +778,4 @@
 "shortcut_play_or_shuffle_dialog" = "Play or shuffle?";
 "share" = "Share";
 "share_link_failed" = "Couldn't create share link.";
+"artwork_open" = "Enlarge image";

--- a/Shelv/fr.lproj/Localizable.strings
+++ b/Shelv/fr.lproj/Localizable.strings
@@ -778,3 +778,4 @@
 "shortcut_play_or_shuffle_dialog" = "Lecture normale ou aléatoire ?";
 "share" = "Partager";
 "share_link_failed" = "Impossible de créer le lien de partage.";
+"artwork_open" = "Agrandir l’image";

--- a/Shelv/zh-Hans.lproj/Localizable.strings
+++ b/Shelv/zh-Hans.lproj/Localizable.strings
@@ -778,3 +778,4 @@
 "shortcut_play_or_shuffle_dialog" = "播放还是随机播放？";
 "share" = "分享";
 "share_link_failed" = "无法创建分享链接。";
+"artwork_open" = "放大图片";

--- a/ShelvCore/Support/ArtworkZoomGeometry.swift
+++ b/ShelvCore/Support/ArtworkZoomGeometry.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// Geometry for the full-screen artwork viewer, shared by every platform that
+/// can open a cover: pinch to zoom, drag to pan, swipe down to close.
+///
+/// Covers are square and shown aspect-fit, so at the fit scale the artwork is
+/// `min(viewport.width, viewport.height)` on a side and never overflows.
+nonisolated enum ArtworkZoomGeometry {
+    /// The artwork fits the viewport; panning is pointless and swipe-down closes.
+    static let minScale: CGFloat = 1
+    /// Past this a 1000px cover is mostly interpolation, so there is nothing to gain.
+    static let maxScale: CGFloat = 4
+    /// Where a double tap lands, chosen so a square cover fills the short side twice over.
+    static let doubleTapScale: CGFloat = 2.5
+    /// How far the artwork has to travel down before the viewer closes.
+    static let dismissDragDistance: CGFloat = 120
+
+    static func clampScale(_ scale: CGFloat) -> CGFloat {
+        min(max(scale, minScale), maxScale)
+    }
+
+    /// How far the artwork can travel on each axis before its edge shows.
+    static func maxOffset(scale: CGFloat, viewport: CGSize) -> CGSize {
+        let side = min(viewport.width, viewport.height) * clampScale(scale)
+        return CGSize(
+            width: max(0, (side - viewport.width) / 2),
+            height: max(0, (side - viewport.height) / 2)
+        )
+    }
+
+    static func clampOffset(_ offset: CGSize, scale: CGFloat, viewport: CGSize) -> CGSize {
+        let limit = maxOffset(scale: scale, viewport: viewport)
+        return CGSize(
+            width: min(max(offset.width, -limit.width), limit.width),
+            height: min(max(offset.height, -limit.height), limit.height)
+        )
+    }
+
+    /// A double tap zooms in from the fit scale and collapses back from anywhere else,
+    /// so it is always a way out of an accidental pinch.
+    static func scaleAfterDoubleTap(current: CGFloat) -> CGFloat {
+        current > minScale ? minScale : doubleTapScale
+    }
+
+    /// Once zoomed in, a downward drag pans the artwork rather than closing the viewer.
+    static func shouldDismiss(verticalDrag: CGFloat, scale: CGFloat) -> Bool {
+        scale <= minScale && verticalDrag >= dismissDragDistance
+    }
+}

--- a/ShelvTests/ArtworkZoomGeometryTests.swift
+++ b/ShelvTests/ArtworkZoomGeometryTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+
+final class ArtworkZoomGeometryTests: XCTestCase {
+    private let viewport = CGSize(width: 400, height: 800)
+
+    func testScaleIsClampedBetweenFitAndMaximum() {
+        XCTAssertEqual(ArtworkZoomGeometry.clampScale(0.2), ArtworkZoomGeometry.minScale)
+        XCTAssertEqual(ArtworkZoomGeometry.clampScale(99), ArtworkZoomGeometry.maxScale)
+        XCTAssertEqual(ArtworkZoomGeometry.clampScale(2), 2)
+    }
+
+    func testArtworkThatFitsTheViewportCannotBePanned() {
+        // A square cover in a 400x800 viewport is 400 wide: nothing overflows.
+        let offset = ArtworkZoomGeometry.clampOffset(
+            CGSize(width: 250, height: -400),
+            scale: 1,
+            viewport: viewport
+        )
+
+        XCTAssertEqual(offset, .zero)
+    }
+
+    func testPanningStopsAtTheArtworkEdges() {
+        // At 2x the cover is 800x800: 200pt of horizontal overflow on each side,
+        // and nothing vertically because the viewport is already 800 tall.
+        let limit = ArtworkZoomGeometry.maxOffset(scale: 2, viewport: viewport)
+        XCTAssertEqual(limit.width, 200)
+        XCTAssertEqual(limit.height, 0)
+
+        let offset = ArtworkZoomGeometry.clampOffset(
+            CGSize(width: 900, height: 900),
+            scale: 2,
+            viewport: viewport
+        )
+        XCTAssertEqual(offset, CGSize(width: 200, height: 0))
+    }
+
+    func testDoubleTapTogglesBetweenFitAndZoom() {
+        XCTAssertEqual(ArtworkZoomGeometry.scaleAfterDoubleTap(current: 1), ArtworkZoomGeometry.doubleTapScale)
+        XCTAssertEqual(ArtworkZoomGeometry.scaleAfterDoubleTap(current: 2.5), ArtworkZoomGeometry.minScale)
+        // Anything above the fit scale collapses back, however it got there.
+        XCTAssertEqual(ArtworkZoomGeometry.scaleAfterDoubleTap(current: 1.2), ArtworkZoomGeometry.minScale)
+    }
+
+    func testSwipeDownDismissesOnlyWhileTheArtworkFitsTheViewport() {
+        XCTAssertTrue(ArtworkZoomGeometry.shouldDismiss(verticalDrag: 200, scale: 1))
+        XCTAssertFalse(ArtworkZoomGeometry.shouldDismiss(verticalDrag: 20, scale: 1))
+        // Zoomed in, a downward drag pans the artwork instead of closing it.
+        XCTAssertFalse(ArtworkZoomGeometry.shouldDismiss(verticalDrag: 400, scale: 2))
+        // Dragging upwards never dismisses.
+        XCTAssertFalse(ArtworkZoomGeometry.shouldDismiss(verticalDrag: -400, scale: 1))
+    }
+}


### PR DESCRIPTION
Navidrome serves artist images at up to 1000x1000 (asking `size=2000` returns the same file), but the artist page only ever shows them at 100pt on iOS and 120pt on macOS. Most of the pixels the server already sent are never visible, and there is no way to see the photo any bigger.

Tapping the artwork now opens it full screen: pinch to zoom up to 4x, drag to pan, double tap to toggle, swipe down or close to dismiss. macOS gets the same through a sheet with double-click zoom and Escape.

Kept deliberately small:

- Loading goes through the existing `AlbumArtView` (iOS) and `CoverArtView` (macOS), so the viewer inherits the memory and disk cache, the retry policy and the offline fallback. No second image pipeline, no new network path.
- Nothing is added to the page. The existing artwork becomes tappable, and is disabled when the artist has no `coverArt`.
- Clamping rules live in `ShelvCore/Support/ArtworkZoomGeometry.swift`, pure and covered by 5 tests, following `ArtistTopSongsRanking`.

One new string, `artwork_open`, in all four languages on both targets.

## Questions

1. **Scope.** Wired on the artist page only, because that is where I hit it. `AlbumDetailView` and the full-screen player are a couple of lines each with the same component. Same PR, or separate?
2. **tvOS.** Left out on purpose: there is no tap-to-zoom idiom on the remote and the TV page already shows large artwork. Tell me if you disagree.
3. **macOS presentation.** A sheet at 640pt was the smaller change; a separate window would also be reasonable.

## Verification

459 iOS tests pass, 5 of them new. macOS builds. tvOS untouched.

## Note

Conflicts with my other open PRs in `Shelv.xcodeproj/project.pbxproj` only — each adds a file to the test target at the same spot. Trivial to resolve, and unavoidable between concurrent Xcode branches.
