### PR TITLE
feat: word-by-word lyrics when the server has the timing

### DIFF
--- a/Shelv Mac/Views/LyricsPanel.swift
+++ b/Shelv Mac/Views/LyricsPanel.swift
@@ -728,59 +728,13 @@ struct LyricsPanel: View {
         }
     }
 
+    /// Enhanced LRC is a superset of LRC, so one parser reads both, and the
+    /// word tags of a karaoke file never leak into the visible text. Shared
+    /// with the other platforms and covered by tests.
     private func parseLRC(_ lrc: String) -> [LyricLine] {
-        var result: [(timeMs: Int, text: String)] = []
-        let pattern = #"\[(\d{1,2}):(\d{2})(?:\.(\d{1,3}))?\]"#
-        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
-
-        for rawLine in lrc.components(separatedBy: "\n") {
-            let line = rawLine.trimmingCharacters(in: .whitespaces)
-            let nsLine = line as NSString
-            let range = NSRange(location: 0, length: nsLine.length)
-
-            let matches = regex.matches(in: line, range: range)
-            guard !matches.isEmpty, let lastMatch = matches.last else { continue }
-
-            let textStart = lastMatch.range.location + lastMatch.range.length
-            guard textStart <= nsLine.length else { continue }
-
-            let text = nsLine.substring(from: textStart).trimmingCharacters(in: .whitespaces)
-            guard !text.isEmpty else { continue }
-
-            for match in matches {
-                guard match.numberOfRanges >= 4 else { continue }
-
-                func group(_ index: Int) -> String {
-                    let groupRange = match.range(at: index)
-                    guard groupRange.location != NSNotFound else { return "" }
-                    return nsLine.substring(with: groupRange)
-                }
-
-                let minutes = Int(group(1)) ?? 0
-                let seconds = Int(group(2)) ?? 0
-                let fraction = group(3)
-                let fractionValue = Int(fraction) ?? 0
-                let fractionMs: Int
-                switch fraction.count {
-                case 1:
-                    fractionMs = fractionValue * 100
-                case 2:
-                    fractionMs = fractionValue * 10
-                default:
-                    fractionMs = fractionValue
-                }
-
-                let totalMs = (minutes * 60 + seconds) * 1000 + fractionMs
-                result.append((timeMs: totalMs, text: text))
-            }
-        }
-
-        return result
-            .sorted { $0.timeMs < $1.timeMs }
+        EnhancedLyricsParser.parse(lrc)
             .enumerated()
-            .map { offset, line in
-                LyricLine(id: offset, timeMs: line.timeMs, text: line.text)
-            }
+            .map { offset, line in LyricLine(id: offset, timeMs: line.start, text: line.text) }
     }
 
     private func plainText(for record: LyricsRecord) -> String? {
@@ -805,19 +759,10 @@ struct LyricsPanel: View {
             .filter { !$0.isEmpty }
     }
 
+    /// Plain text out of an LRC document, word tags included.
     private func stripLRCTimestamps(from lrc: String) -> String {
-        let pattern = #"\[\d{1,2}:\d{2}(?:\.\d{1,3})?\]"#
-        guard let regex = try? NSRegularExpression(pattern: pattern) else { return lrc }
-
-        return lrc
-            .components(separatedBy: "\n")
-            .map { rawLine in
-                let range = NSRange(rawLine.startIndex..<rawLine.endIndex, in: rawLine)
-                return regex
-                    .stringByReplacingMatches(in: rawLine, range: range, withTemplate: "")
-                    .trimmingCharacters(in: .whitespaces)
-            }
-            .filter { !$0.isEmpty }
+        EnhancedLyricsParser.parse(lrc)
+            .map(\.text)
             .joined(separator: "\n")
     }
 }

--- a/Shelv TV/Views/NowPlaying/LyricsView.swift
+++ b/Shelv TV/Views/NowPlaying/LyricsView.swift
@@ -432,59 +432,13 @@ struct LyricsView: View {
         proxy.scrollTo(parsedLines[targetIndex].id, anchor: anchor)
     }
 
+    /// Enhanced LRC is a superset of LRC, so one parser reads both, and the
+    /// word tags of a karaoke file never leak into the visible text. Shared
+    /// with the other platforms and covered by tests.
     private func parseLRC(_ lrc: String) -> [LyricLine] {
-        var result: [(timeMs: Int, text: String)] = []
-        let pattern = #"\[(\d{1,2}):(\d{2})(?:\.(\d{1,3}))?\]"#
-        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
-
-        for rawLine in lrc.components(separatedBy: "\n") {
-            let line = rawLine.trimmingCharacters(in: .whitespaces)
-            let nsLine = line as NSString
-            let range = NSRange(location: 0, length: nsLine.length)
-
-            let matches = regex.matches(in: line, range: range)
-            guard !matches.isEmpty, let lastMatch = matches.last else { continue }
-
-            let textStart = lastMatch.range.location + lastMatch.range.length
-            guard textStart <= nsLine.length else { continue }
-
-            let text = nsLine.substring(from: textStart).trimmingCharacters(in: .whitespaces)
-            guard !text.isEmpty else { continue }
-
-            for match in matches {
-                guard match.numberOfRanges >= 4 else { continue }
-
-                func group(_ index: Int) -> String {
-                    let groupRange = match.range(at: index)
-                    guard groupRange.location != NSNotFound else { return "" }
-                    return nsLine.substring(with: groupRange)
-                }
-
-                let minutes = Int(group(1)) ?? 0
-                let seconds = Int(group(2)) ?? 0
-                let fraction = group(3)
-                let fractionValue = Int(fraction) ?? 0
-                let fractionMs: Int
-                switch fraction.count {
-                case 1:
-                    fractionMs = fractionValue * 100
-                case 2:
-                    fractionMs = fractionValue * 10
-                default:
-                    fractionMs = fractionValue
-                }
-
-                let totalMs = (minutes * 60 + seconds) * 1000 + fractionMs
-                result.append((timeMs: totalMs, text: text))
-            }
-        }
-
-        return result
-            .sorted { $0.timeMs < $1.timeMs }
+        EnhancedLyricsParser.parse(lrc)
             .enumerated()
-            .map { offset, line in
-                LyricLine(id: offset, timeMs: line.timeMs, text: line.text)
-            }
+            .map { offset, line in LyricLine(id: offset, timeMs: line.start, text: line.text) }
     }
 
     private func plainText(for record: LyricsRecord) -> String? {
@@ -509,19 +463,10 @@ struct LyricsView: View {
             .filter { !$0.isEmpty }
     }
 
+    /// Plain text out of an LRC document, word tags included.
     private func stripLRCTimestamps(from lrc: String) -> String {
-        let pattern = #"\[\d{1,2}:\d{2}(?:\.\d{1,3})?\]"#
-        guard let regex = try? NSRegularExpression(pattern: pattern) else { return lrc }
-
-        return lrc
-            .components(separatedBy: "\n")
-            .map { rawLine in
-                let range = NSRange(rawLine.startIndex..<rawLine.endIndex, in: rawLine)
-                return regex
-                    .stringByReplacingMatches(in: rawLine, range: range, withTemplate: "")
-                    .trimmingCharacters(in: .whitespaces)
-            }
-            .filter { !$0.isEmpty }
+        EnhancedLyricsParser.parse(lrc)
+            .map(\.text)
             .joined(separator: "\n")
     }
 }

--- a/Shelv.xcodeproj/project.pbxproj
+++ b/Shelv.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		11F3AAFBB4684ECFABA0E3E5 /* ShelvCore/Models/RecapPeriod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3481C1649E04481CA0F35E60 /* ShelvCore/Models/RecapPeriod.swift */; };
 		4B666BEAD970D72DFCFF9C7E /* ShelvCore/Services/RadioStationChangeLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8C9F16F5098EE7158A393F2 /* ShelvCore/Services/RadioStationChangeLogic.swift */; };
+		BBF00507000000000000C0DE /* ShelvCore/Support/OpenSubsonicCapabilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF00507000000000000C0DE /* ShelvCore/Support/OpenSubsonicCapabilities.swift */; };
 		4C9CE80450C542811BFC06B9 /* ShelvCore/Services/ArtistTopSongsRanking.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2D3956FCB8E5BA0EA7B365B /* ShelvCore/Services/ArtistTopSongsRanking.swift */; };
 		BBF091A70FDE00000000C0DE /* ShelvCore/Services/ArtistPlayOrder.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF091A70FDE00000000C0DE /* ShelvCore/Services/ArtistPlayOrder.swift */; };
 		54755D0F4F7624D1CB2AFAA0 /* ShelvCore/Services/RemoteStreamFailureRetryPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D76D0722C024A55F5646646B /* ShelvCore/Services/RemoteStreamFailureRetryPolicy.swift */; };
@@ -56,7 +57,6 @@
 		BC1001502FFE000000000001 /* ShelvCore/Services/SubsonicResponseCompatibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1001512FFE000000000001 /* ShelvCore/Services/SubsonicResponseCompatibility.swift */; };
 		BC1001522FFE000000000001 /* ShelvCore/Stores/SearchHistoryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1001532FFE000000000001 /* ShelvCore/Stores/SearchHistoryStore.swift */; };
 		BC1001542FFE000000000001 /* ShelvCore/Support/AlphabetIndexSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1001552FFE000000000001 /* ShelvCore/Support/AlphabetIndexSelection.swift */; };
-		BBF00507000000000000C0DE /* ShelvCore/Support/OpenSubsonicCapabilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF00507000000000000C0DE /* ShelvCore/Support/OpenSubsonicCapabilities.swift */; };
 		BC1001602FFE000000000001 /* ShelvCore/Services/InfinityMixPoolBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1001612FFE000000000001 /* ShelvCore/Services/InfinityMixPoolBuilder.swift */; };
 		BC1867E52F91A088006D96E2 /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = BC1867E42F91A088006D96E2 /* GRDB */; };
 		BC51161D2FDC8A850011CDE9 /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = BC51161C2FDC8A850011CDE9 /* GRDB */; };
@@ -143,7 +143,6 @@
 		BC1001512FFE000000000001 /* ShelvCore/Services/SubsonicResponseCompatibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/SubsonicResponseCompatibility.swift; sourceTree = "<group>"; };
 		BC1001532FFE000000000001 /* ShelvCore/Stores/SearchHistoryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Stores/SearchHistoryStore.swift; sourceTree = "<group>"; };
 		BC1001552FFE000000000001 /* ShelvCore/Support/AlphabetIndexSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Support/AlphabetIndexSelection.swift; sourceTree = "<group>"; };
-		AAF00507000000000000C0DE /* ShelvCore/Support/OpenSubsonicCapabilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Support/OpenSubsonicCapabilities.swift; sourceTree = "<group>"; };
 		BC1001612FFE000000000001 /* ShelvCore/Services/InfinityMixPoolBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/InfinityMixPoolBuilder.swift; sourceTree = "<group>"; };
 		BC2000012FFE000000000001 /* ShelvAppIntentsUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ShelvAppIntentsUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BC5116112FDC8A690011CDE9 /* Shelv TV.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Shelv TV.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -151,6 +150,7 @@
 		BC7B83F52FDB17700058CB78 /* Shelv.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Shelv.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BC9C59382F8E9FB000FF4D25 /* Shelv.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Shelv.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C8C9F16F5098EE7158A393F2 /* ShelvCore/Services/RadioStationChangeLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/RadioStationChangeLogic.swift; sourceTree = "<group>"; };
+		AAF00507000000000000C0DE /* ShelvCore/Support/OpenSubsonicCapabilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Support/OpenSubsonicCapabilities.swift; sourceTree = "<group>"; };
 		D602F58338426465B1E367C5 /* ShelvCore/Services/RecapExpectedSongsLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/RecapExpectedSongsLogic.swift; sourceTree = "<group>"; };
 		D76D0722C024A55F5646646B /* ShelvCore/Services/RemoteStreamFailureRetryPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/RemoteStreamFailureRetryPolicy.swift; sourceTree = "<group>"; };
 		DB776033CC96417A93CA66DB /* ShelvCore/Services/ConcurrencyLimiter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/ConcurrencyLimiter.swift; sourceTree = "<group>"; };
@@ -280,6 +280,7 @@
 				BC1001232FFE000000000001 /* ShelvCore/Models/RadioStation.swift */,
 				BC1001272FFE000000000001 /* ShelvCore/Models/SubsonicServer.swift */,
 				C8C9F16F5098EE7158A393F2 /* ShelvCore/Services/RadioStationChangeLogic.swift */,
+				AAF00507000000000000C0DE /* ShelvCore/Support/OpenSubsonicCapabilities.swift */,
 				7032627BABC540CC8752182E /* ShelvCore/Services/PlaylistDuplicateChecker.swift */,
 				FFBB0EAEC930A6AA93845AF6 /* ShelvCore/Services/ArtistDiscography.swift */,
 				F2D3956FCB8E5BA0EA7B365B /* ShelvCore/Services/ArtistTopSongsRanking.swift */,
@@ -320,7 +321,6 @@
 				BC1001512FFE000000000001 /* ShelvCore/Services/SubsonicResponseCompatibility.swift */,
 				BC1001532FFE000000000001 /* ShelvCore/Stores/SearchHistoryStore.swift */,
 				BC1001552FFE000000000001 /* ShelvCore/Support/AlphabetIndexSelection.swift */,
-				AAF00507000000000000C0DE /* ShelvCore/Support/OpenSubsonicCapabilities.swift */,
 				BC10014D2FFE000000000001 /* ShelvCore/Stores/DownloadUIStateHub.swift */,
 			);
 			name = "ShelvCore Test Sources";
@@ -634,6 +634,7 @@
 				BC1001222FFE000000000001 /* ShelvCore/Models/RadioStation.swift in Sources */,
 				BC1001262FFE000000000001 /* ShelvCore/Models/SubsonicServer.swift in Sources */,
 				4B666BEAD970D72DFCFF9C7E /* ShelvCore/Services/RadioStationChangeLogic.swift in Sources */,
+				BBF00507000000000000C0DE /* ShelvCore/Support/OpenSubsonicCapabilities.swift in Sources */,
 				767C48F98385493A929D3CF5 /* ShelvCore/Services/PlaylistDuplicateChecker.swift in Sources */,
 				A3BC3F4796D89CE06D73AEBA /* ShelvCore/Services/ArtistDiscography.swift in Sources */,
 				4C9CE80450C542811BFC06B9 /* ShelvCore/Services/ArtistTopSongsRanking.swift in Sources */,
@@ -674,7 +675,6 @@
 				BC1001502FFE000000000001 /* ShelvCore/Services/SubsonicResponseCompatibility.swift in Sources */,
 				BC1001522FFE000000000001 /* ShelvCore/Stores/SearchHistoryStore.swift in Sources */,
 				BC1001542FFE000000000001 /* ShelvCore/Support/AlphabetIndexSelection.swift in Sources */,
-				BBF00507000000000000C0DE /* ShelvCore/Support/OpenSubsonicCapabilities.swift in Sources */,
 				BC10014C2FFE000000000001 /* ShelvCore/Stores/DownloadUIStateHub.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Shelv.xcodeproj/project.pbxproj
+++ b/Shelv.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		BBF091A70FDE00000000C0DE /* ShelvCore/Services/ArtistPlayOrder.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF091A70FDE00000000C0DE /* ShelvCore/Services/ArtistPlayOrder.swift */; };
 		54755D0F4F7624D1CB2AFAA0 /* ShelvCore/Services/RemoteStreamFailureRetryPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D76D0722C024A55F5646646B /* ShelvCore/Services/RemoteStreamFailureRetryPolicy.swift */; };
 		767C48F98385493A929D3CF5 /* ShelvCore/Services/PlaylistDuplicateChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7032627BABC540CC8752182E /* ShelvCore/Services/PlaylistDuplicateChecker.swift */; };
+		BBF01471C500000000000000 /* ShelvCore/Services/EnhancedLyrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF01471C500000000000000 /* ShelvCore/Services/EnhancedLyrics.swift */; };
 		A3BC3F4796D89CE06D73AEBA /* ShelvCore/Services/ArtistDiscography.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFBB0EAEC930A6AA93845AF6 /* ShelvCore/Services/ArtistDiscography.swift */; };
 		A6370E2FCC02E636B1CE06BB /* ShelvCore/Services/PlayLogReconciliationLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EB765BFF905DC588F357EC2 /* ShelvCore/Services/PlayLogReconciliationLogic.swift */; };
 		BC10000C2FFE000000000001 /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = BC10000D2FFE000000000001 /* GRDB */; };
@@ -57,7 +58,6 @@
 		BC1001502FFE000000000001 /* ShelvCore/Services/SubsonicResponseCompatibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1001512FFE000000000001 /* ShelvCore/Services/SubsonicResponseCompatibility.swift */; };
 		BC1001522FFE000000000001 /* ShelvCore/Stores/SearchHistoryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1001532FFE000000000001 /* ShelvCore/Stores/SearchHistoryStore.swift */; };
 		BC1001542FFE000000000001 /* ShelvCore/Support/AlphabetIndexSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1001552FFE000000000001 /* ShelvCore/Support/AlphabetIndexSelection.swift */; };
-		BBF01471C500000000000000 /* ShelvCore/Services/EnhancedLyrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF01471C500000000000000 /* ShelvCore/Services/EnhancedLyrics.swift */; };
 		BC1001602FFE000000000001 /* ShelvCore/Services/InfinityMixPoolBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1001612FFE000000000001 /* ShelvCore/Services/InfinityMixPoolBuilder.swift */; };
 		BC1867E52F91A088006D96E2 /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = BC1867E42F91A088006D96E2 /* GRDB */; };
 		BC51161D2FDC8A850011CDE9 /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = BC51161C2FDC8A850011CDE9 /* GRDB */; };
@@ -103,6 +103,7 @@
 		1EB765BFF905DC588F357EC2 /* ShelvCore/Services/PlayLogReconciliationLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/PlayLogReconciliationLogic.swift; sourceTree = "<group>"; };
 		3481C1649E04481CA0F35E60 /* ShelvCore/Models/RecapPeriod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Models/RecapPeriod.swift; sourceTree = "<group>"; };
 		7032627BABC540CC8752182E /* ShelvCore/Services/PlaylistDuplicateChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/PlaylistDuplicateChecker.swift; sourceTree = "<group>"; };
+		AAF01471C500000000000000 /* ShelvCore/Services/EnhancedLyrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/EnhancedLyrics.swift; sourceTree = "<group>"; };
 		BC1000012FFE000000000001 /* ShelvTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ShelvTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BC1001112FFE000000000001 /* ShelvCore/Models/Album.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Models/Album.swift; sourceTree = "<group>"; };
 		BC1001122FFE000000000001 /* ShelvCore/Models/Artist.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Models/Artist.swift; sourceTree = "<group>"; };
@@ -144,7 +145,6 @@
 		BC1001512FFE000000000001 /* ShelvCore/Services/SubsonicResponseCompatibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/SubsonicResponseCompatibility.swift; sourceTree = "<group>"; };
 		BC1001532FFE000000000001 /* ShelvCore/Stores/SearchHistoryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Stores/SearchHistoryStore.swift; sourceTree = "<group>"; };
 		BC1001552FFE000000000001 /* ShelvCore/Support/AlphabetIndexSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Support/AlphabetIndexSelection.swift; sourceTree = "<group>"; };
-		AAF01471C500000000000000 /* ShelvCore/Services/EnhancedLyrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/EnhancedLyrics.swift; sourceTree = "<group>"; };
 		BC1001612FFE000000000001 /* ShelvCore/Services/InfinityMixPoolBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/InfinityMixPoolBuilder.swift; sourceTree = "<group>"; };
 		BC2000012FFE000000000001 /* ShelvAppIntentsUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ShelvAppIntentsUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BC5116112FDC8A690011CDE9 /* Shelv TV.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Shelv TV.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -284,6 +284,7 @@
 				C8C9F16F5098EE7158A393F2 /* ShelvCore/Services/RadioStationChangeLogic.swift */,
 				AAF00507000000000000C0DE /* ShelvCore/Support/OpenSubsonicCapabilities.swift */,
 				7032627BABC540CC8752182E /* ShelvCore/Services/PlaylistDuplicateChecker.swift */,
+				AAF01471C500000000000000 /* ShelvCore/Services/EnhancedLyrics.swift */,
 				FFBB0EAEC930A6AA93845AF6 /* ShelvCore/Services/ArtistDiscography.swift */,
 				F2D3956FCB8E5BA0EA7B365B /* ShelvCore/Services/ArtistTopSongsRanking.swift */,
 				AAF091A70FDE00000000C0DE /* ShelvCore/Services/ArtistPlayOrder.swift */,
@@ -323,7 +324,6 @@
 				BC1001512FFE000000000001 /* ShelvCore/Services/SubsonicResponseCompatibility.swift */,
 				BC1001532FFE000000000001 /* ShelvCore/Stores/SearchHistoryStore.swift */,
 				BC1001552FFE000000000001 /* ShelvCore/Support/AlphabetIndexSelection.swift */,
-				AAF01471C500000000000000 /* ShelvCore/Services/EnhancedLyrics.swift */,
 				BC10014D2FFE000000000001 /* ShelvCore/Stores/DownloadUIStateHub.swift */,
 			);
 			name = "ShelvCore Test Sources";
@@ -639,6 +639,7 @@
 				4B666BEAD970D72DFCFF9C7E /* ShelvCore/Services/RadioStationChangeLogic.swift in Sources */,
 				BBF00507000000000000C0DE /* ShelvCore/Support/OpenSubsonicCapabilities.swift in Sources */,
 				767C48F98385493A929D3CF5 /* ShelvCore/Services/PlaylistDuplicateChecker.swift in Sources */,
+				BBF01471C500000000000000 /* ShelvCore/Services/EnhancedLyrics.swift in Sources */,
 				A3BC3F4796D89CE06D73AEBA /* ShelvCore/Services/ArtistDiscography.swift in Sources */,
 				4C9CE80450C542811BFC06B9 /* ShelvCore/Services/ArtistTopSongsRanking.swift in Sources */,
 				BBF091A70FDE00000000C0DE /* ShelvCore/Services/ArtistPlayOrder.swift in Sources */,
@@ -678,7 +679,6 @@
 				BC1001502FFE000000000001 /* ShelvCore/Services/SubsonicResponseCompatibility.swift in Sources */,
 				BC1001522FFE000000000001 /* ShelvCore/Stores/SearchHistoryStore.swift in Sources */,
 				BC1001542FFE000000000001 /* ShelvCore/Support/AlphabetIndexSelection.swift in Sources */,
-				BBF01471C500000000000000 /* ShelvCore/Services/EnhancedLyrics.swift in Sources */,
 				BC10014C2FFE000000000001 /* ShelvCore/Stores/DownloadUIStateHub.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Shelv.xcodeproj/project.pbxproj
+++ b/Shelv.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		BC1001502FFE000000000001 /* ShelvCore/Services/SubsonicResponseCompatibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1001512FFE000000000001 /* ShelvCore/Services/SubsonicResponseCompatibility.swift */; };
 		BC1001522FFE000000000001 /* ShelvCore/Stores/SearchHistoryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1001532FFE000000000001 /* ShelvCore/Stores/SearchHistoryStore.swift */; };
 		BC1001542FFE000000000001 /* ShelvCore/Support/AlphabetIndexSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1001552FFE000000000001 /* ShelvCore/Support/AlphabetIndexSelection.swift */; };
+		BBF00507000000000000C0DE /* ShelvCore/Support/OpenSubsonicCapabilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF00507000000000000C0DE /* ShelvCore/Support/OpenSubsonicCapabilities.swift */; };
 		BC1001602FFE000000000001 /* ShelvCore/Services/InfinityMixPoolBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1001612FFE000000000001 /* ShelvCore/Services/InfinityMixPoolBuilder.swift */; };
 		BC1867E52F91A088006D96E2 /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = BC1867E42F91A088006D96E2 /* GRDB */; };
 		BC51161D2FDC8A850011CDE9 /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = BC51161C2FDC8A850011CDE9 /* GRDB */; };
@@ -142,6 +143,7 @@
 		BC1001512FFE000000000001 /* ShelvCore/Services/SubsonicResponseCompatibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/SubsonicResponseCompatibility.swift; sourceTree = "<group>"; };
 		BC1001532FFE000000000001 /* ShelvCore/Stores/SearchHistoryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Stores/SearchHistoryStore.swift; sourceTree = "<group>"; };
 		BC1001552FFE000000000001 /* ShelvCore/Support/AlphabetIndexSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Support/AlphabetIndexSelection.swift; sourceTree = "<group>"; };
+		AAF00507000000000000C0DE /* ShelvCore/Support/OpenSubsonicCapabilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Support/OpenSubsonicCapabilities.swift; sourceTree = "<group>"; };
 		BC1001612FFE000000000001 /* ShelvCore/Services/InfinityMixPoolBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/InfinityMixPoolBuilder.swift; sourceTree = "<group>"; };
 		BC2000012FFE000000000001 /* ShelvAppIntentsUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ShelvAppIntentsUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BC5116112FDC8A690011CDE9 /* Shelv TV.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Shelv TV.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -318,6 +320,7 @@
 				BC1001512FFE000000000001 /* ShelvCore/Services/SubsonicResponseCompatibility.swift */,
 				BC1001532FFE000000000001 /* ShelvCore/Stores/SearchHistoryStore.swift */,
 				BC1001552FFE000000000001 /* ShelvCore/Support/AlphabetIndexSelection.swift */,
+				AAF00507000000000000C0DE /* ShelvCore/Support/OpenSubsonicCapabilities.swift */,
 				BC10014D2FFE000000000001 /* ShelvCore/Stores/DownloadUIStateHub.swift */,
 			);
 			name = "ShelvCore Test Sources";
@@ -671,6 +674,7 @@
 				BC1001502FFE000000000001 /* ShelvCore/Services/SubsonicResponseCompatibility.swift in Sources */,
 				BC1001522FFE000000000001 /* ShelvCore/Stores/SearchHistoryStore.swift in Sources */,
 				BC1001542FFE000000000001 /* ShelvCore/Support/AlphabetIndexSelection.swift in Sources */,
+				BBF00507000000000000C0DE /* ShelvCore/Support/OpenSubsonicCapabilities.swift in Sources */,
 				BC10014C2FFE000000000001 /* ShelvCore/Stores/DownloadUIStateHub.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Shelv.xcodeproj/project.pbxproj
+++ b/Shelv.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		BC1001502FFE000000000001 /* ShelvCore/Services/SubsonicResponseCompatibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1001512FFE000000000001 /* ShelvCore/Services/SubsonicResponseCompatibility.swift */; };
 		BC1001522FFE000000000001 /* ShelvCore/Stores/SearchHistoryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1001532FFE000000000001 /* ShelvCore/Stores/SearchHistoryStore.swift */; };
 		BC1001542FFE000000000001 /* ShelvCore/Support/AlphabetIndexSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1001552FFE000000000001 /* ShelvCore/Support/AlphabetIndexSelection.swift */; };
+		BBF01471C500000000000000 /* ShelvCore/Services/EnhancedLyrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF01471C500000000000000 /* ShelvCore/Services/EnhancedLyrics.swift */; };
 		BC1001602FFE000000000001 /* ShelvCore/Services/InfinityMixPoolBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1001612FFE000000000001 /* ShelvCore/Services/InfinityMixPoolBuilder.swift */; };
 		BC1867E52F91A088006D96E2 /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = BC1867E42F91A088006D96E2 /* GRDB */; };
 		BC51161D2FDC8A850011CDE9 /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = BC51161C2FDC8A850011CDE9 /* GRDB */; };
@@ -143,6 +144,7 @@
 		BC1001512FFE000000000001 /* ShelvCore/Services/SubsonicResponseCompatibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/SubsonicResponseCompatibility.swift; sourceTree = "<group>"; };
 		BC1001532FFE000000000001 /* ShelvCore/Stores/SearchHistoryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Stores/SearchHistoryStore.swift; sourceTree = "<group>"; };
 		BC1001552FFE000000000001 /* ShelvCore/Support/AlphabetIndexSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Support/AlphabetIndexSelection.swift; sourceTree = "<group>"; };
+		AAF01471C500000000000000 /* ShelvCore/Services/EnhancedLyrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/EnhancedLyrics.swift; sourceTree = "<group>"; };
 		BC1001612FFE000000000001 /* ShelvCore/Services/InfinityMixPoolBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/InfinityMixPoolBuilder.swift; sourceTree = "<group>"; };
 		BC2000012FFE000000000001 /* ShelvAppIntentsUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ShelvAppIntentsUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BC5116112FDC8A690011CDE9 /* Shelv TV.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Shelv TV.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -321,6 +323,7 @@
 				BC1001512FFE000000000001 /* ShelvCore/Services/SubsonicResponseCompatibility.swift */,
 				BC1001532FFE000000000001 /* ShelvCore/Stores/SearchHistoryStore.swift */,
 				BC1001552FFE000000000001 /* ShelvCore/Support/AlphabetIndexSelection.swift */,
+				AAF01471C500000000000000 /* ShelvCore/Services/EnhancedLyrics.swift */,
 				BC10014D2FFE000000000001 /* ShelvCore/Stores/DownloadUIStateHub.swift */,
 			);
 			name = "ShelvCore Test Sources";
@@ -675,6 +678,7 @@
 				BC1001502FFE000000000001 /* ShelvCore/Services/SubsonicResponseCompatibility.swift in Sources */,
 				BC1001522FFE000000000001 /* ShelvCore/Stores/SearchHistoryStore.swift in Sources */,
 				BC1001542FFE000000000001 /* ShelvCore/Support/AlphabetIndexSelection.swift in Sources */,
+				BBF01471C500000000000000 /* ShelvCore/Services/EnhancedLyrics.swift in Sources */,
 				BC10014C2FFE000000000001 /* ShelvCore/Stores/DownloadUIStateHub.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Shelv/Services/LyricsBackgroundService.swift
+++ b/Shelv/Services/LyricsBackgroundService.swift
@@ -462,14 +462,8 @@ actor LyricsBackgroundService {
 
         var lrc: String? = nil
         if entry.synced {
-            let lrcLines = lines.compactMap { line -> String? in
-                guard let ms = line.start else { return nil }
-                let min = (ms / 1000) / 60
-                let sec = (ms / 1000) % 60
-                let cs  = (ms % 1000) / 10
-                return String(format: "[%02d:%02d.%02d] %@", min, sec, cs, line.value)
-            }
-            lrc = lrcLines.isEmpty ? nil : lrcLines.joined(separator: "\n")
+            let timed = entry.timedLines
+            lrc = timed.isEmpty ? nil : EnhancedLyricsParser.serialize(timed)
         }
 
         return LyricsRecord(

--- a/Shelv/Views/Player/LyricsSheetView.swift
+++ b/Shelv/Views/Player/LyricsSheetView.swift
@@ -8,8 +8,11 @@ private let lyricsNativeActiveLineAnchor = UnitPoint(x: 0.5, y: 0.12)
 
 private struct LyricLine: Identifiable {
     let id: Int
-    let timeMs: Int
-    let text: String
+    let timed: TimedLyricLine
+
+    var timeMs: Int { timed.start }
+    var text: String { timed.text }
+    var hasWordTiming: Bool { timed.hasWordTiming }
 }
 
 private struct LyricLineRow: View {
@@ -58,6 +61,7 @@ private struct NativeLyricLineRow: View {
     let isActive: Bool
     let distance: Int
     let isUserScrolling: Bool
+    let currentTimeMs: Int
     let onTap: () -> Void
 
     private var isPad: Bool { UIDevice.current.userInterfaceIdiom == .pad }
@@ -95,9 +99,28 @@ private struct NativeLyricLineRow: View {
         }
     }
 
+    /// Words already sung stay lit while the rest of the line waits its turn.
+    /// A per-word `foregroundColor` inside a concatenated `Text` beats the outer
+    /// style, and concatenation keeps normal line wrapping.
+    private var styledText: Text {
+        guard isActive,
+              line.hasWordTiming,
+              let active = LyricsKaraokeTiming.activeWordIndex(in: line.timed, at: currentTimeMs)
+        else {
+            return Text(line.text)
+        }
+        let words = line.timed.words
+        return words.enumerated().reduce(Text("")) { partial, entry in
+            let (index, word) = entry
+            let separator = index == words.count - 1 ? "" : " "
+            return partial + Text(word.value + separator)
+                .foregroundColor(Color.primary.opacity(index <= active ? 1 : 0.32))
+        }
+    }
+
     var body: some View {
         Button(action: onTap) {
-            Text(line.text)
+            styledText
                 .font(lyricFont)
                 .lineSpacing(isPad ? 5 : 4)
                 .foregroundStyle(Color.primary.opacity(opacity))
@@ -410,6 +433,10 @@ struct LyricsSheetView: View {
                             isActive: isActive,
                             distance: distance,
                             isUserScrolling: isUserScrolling,
+                            // Only the active row reads the clock. Handing the
+                            // live value to every row would re-render the whole
+                            // stack on each tick for nothing.
+                            currentTimeMs: isActive ? currentTimeMs : 0,
                             onTap: {
                                 let seconds = Double(line.timeMs) / 1000.0
                                 player.seek(to: seconds)
@@ -743,59 +770,13 @@ struct LyricsSheetView: View {
         }
     }
 
+    /// Enhanced LRC is a superset of LRC, so one parser reads both: a file
+    /// without word tags simply yields lines with no words. Shared with the
+    /// lyrics writer and covered by tests, rather than a second regex here.
     private func parseLRC(_ lrc: String) -> [LyricLine] {
-        var result: [(timeMs: Int, text: String)] = []
-        let pattern = #"\[(\d{1,2}):(\d{2})(?:\.(\d{1,3}))?\]"#
-        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
-
-        for rawLine in lrc.components(separatedBy: "\n") {
-            let line = rawLine.trimmingCharacters(in: .whitespaces)
-            let nsLine = line as NSString
-            let range = NSRange(location: 0, length: nsLine.length)
-
-            let matches = regex.matches(in: line, range: range)
-            guard !matches.isEmpty, let lastMatch = matches.last else { continue }
-
-            let textStart = lastMatch.range.location + lastMatch.range.length
-            guard textStart <= nsLine.length else { continue }
-
-            let text = nsLine.substring(from: textStart).trimmingCharacters(in: .whitespaces)
-            guard !text.isEmpty else { continue }
-
-            for match in matches {
-                guard match.numberOfRanges >= 4 else { continue }
-
-                func group(_ index: Int) -> String {
-                    let groupRange = match.range(at: index)
-                    guard groupRange.location != NSNotFound else { return "" }
-                    return nsLine.substring(with: groupRange)
-                }
-
-                let minutes = Int(group(1)) ?? 0
-                let seconds = Int(group(2)) ?? 0
-                let fraction = group(3)
-                let fractionValue = Int(fraction) ?? 0
-                let fractionMs: Int
-                switch fraction.count {
-                case 1:
-                    fractionMs = fractionValue * 100
-                case 2:
-                    fractionMs = fractionValue * 10
-                default:
-                    fractionMs = fractionValue
-                }
-
-                let totalMs = (minutes * 60 + seconds) * 1000 + fractionMs
-                result.append((timeMs: totalMs, text: text))
-            }
-        }
-
-        return result
-            .sorted { $0.timeMs < $1.timeMs }
+        EnhancedLyricsParser.parse(lrc)
             .enumerated()
-            .map { offset, line in
-                LyricLine(id: offset, timeMs: line.timeMs, text: line.text)
-            }
+            .map { offset, line in LyricLine(id: offset, timed: line) }
     }
 
     private func plainText(for record: LyricsRecord) -> String? {
@@ -820,19 +801,10 @@ struct LyricsSheetView: View {
             .filter { !$0.isEmpty }
     }
 
+    /// Plain text out of an LRC document, word tags included.
     private func stripLRCTimestamps(from lrc: String) -> String {
-        let pattern = #"\[\d{1,2}:\d{2}(?:\.\d{1,3})?\]"#
-        guard let regex = try? NSRegularExpression(pattern: pattern) else { return lrc }
-
-        return lrc
-            .components(separatedBy: "\n")
-            .map { rawLine in
-                let range = NSRange(rawLine.startIndex..<rawLine.endIndex, in: rawLine)
-                return regex
-                    .stringByReplacingMatches(in: rawLine, range: range, withTemplate: "")
-                    .trimmingCharacters(in: .whitespaces)
-            }
-            .filter { !$0.isEmpty }
+        EnhancedLyricsParser.parse(lrc)
+            .map(\.text)
             .joined(separator: "\n")
     }
 }

--- a/ShelvCore/Services/EnhancedLyrics.swift
+++ b/ShelvCore/Services/EnhancedLyrics.swift
@@ -1,0 +1,191 @@
+import Foundation
+
+/// One word or syllable with its own timing, as carried by Enhanced LRC word
+/// tags and by the OpenSubsonic v2 `cueLine` array.
+nonisolated struct TimedWord: Equatable, Sendable {
+    let value: String
+    let start: Int
+    let end: Int
+}
+
+/// A line of lyrics. `words` is empty for ordinary line-timed lyrics, which is
+/// the normal case: LRCLIB serves no word timing at all.
+nonisolated struct TimedLyricLine: Equatable, Sendable {
+    let start: Int
+    let text: String
+    let words: [TimedWord]
+
+    var hasWordTiming: Bool { !words.isEmpty }
+}
+
+/// Reads and writes LRC, including the Enhanced LRC word tags that carry
+/// karaoke timing:
+///
+///     [00:12.00]<00:12.00>The <00:12.50>quick <00:13.00>fox
+///
+/// Enhanced LRC is a superset of LRC, so one parser covers both and a file
+/// without word tags simply yields lines with no words.
+nonisolated enum EnhancedLyricsParser {
+    static func parse(_ lrc: String) -> [TimedLyricLine] {
+        var parsed: [(start: Int, text: String, words: [TimedWord])] = []
+
+        for raw in lrc.split(separator: "\n", omittingEmptySubsequences: false) {
+            var rest = Substring(raw).trimmingCharacters(in: .whitespaces)[...]
+            var starts: [Int] = []
+
+            // A line may repeat: [00:10.00][01:20.00]same chorus.
+            while let tag = leadingTag(in: rest, open: "[", close: "]") {
+                guard let millis = milliseconds(tag.body) else { break }
+                starts.append(millis)
+                rest = tag.remainder
+            }
+            guard !starts.isEmpty else { continue }
+
+            let (rawText, words) = splitWordTags(String(rest))
+            // LRC writers commonly put a space after the closing bracket.
+            let text = rawText.trimmingCharacters(in: .whitespaces)
+            guard !text.isEmpty else { continue }
+            for start in starts {
+                parsed.append((start: start, text: text, words: words))
+            }
+        }
+
+        parsed.sort { $0.start < $1.start }
+
+        // The last word of a line runs until the next line begins; without this
+        // the highlight would blink off in every gap between lines.
+        return parsed.enumerated().map { index, line in
+            let lineEnd = index + 1 < parsed.count ? parsed[index + 1].start : nil
+            return TimedLyricLine(
+                start: line.start,
+                text: line.text,
+                words: closeOpenEnds(line.words, lineEnd: lineEnd)
+            )
+        }
+    }
+
+    static func serialize(_ lines: [TimedLyricLine]) -> String {
+        lines.map { line in
+            guard line.hasWordTiming else {
+                return "[\(timestamp(line.start))]\(line.text)"
+            }
+            let body = line.words
+                .map { "<\(timestamp($0.start))>\($0.value)" }
+                .joined(separator: " ")
+            return "[\(timestamp(line.start))]\(body)"
+        }
+        .joined(separator: "\n")
+    }
+
+    // MARK: - Scanning
+
+    private static func leadingTag(
+        in text: Substring,
+        open: Character,
+        close: Character
+    ) -> (body: String, remainder: Substring)? {
+        guard text.first == open, let end = text.firstIndex(of: close) else { return nil }
+        let body = text[text.index(after: text.startIndex)..<end]
+        return (String(body), text[text.index(after: end)...])
+    }
+
+    /// Splits `<mm:ss.xx>word` runs into visible text and word timings. A line
+    /// with no word tags comes back unchanged with no words.
+    private static func splitWordTags(_ content: String) -> (text: String, words: [TimedWord]) {
+        var text = ""
+        var words: [TimedWord] = []
+        var pendingStart: Int?
+        var buffer = ""
+        var rest = content[...]
+
+        func flush() {
+            guard let start = pendingStart else { return }
+            let value = buffer.trimmingCharacters(in: .whitespaces)
+            if !value.isEmpty {
+                words.append(TimedWord(value: value, start: start, end: start))
+            }
+            pendingStart = nil
+            buffer = ""
+        }
+
+        while let index = rest.firstIndex(of: "<") {
+            let head = rest[rest.startIndex..<index]
+            text += head
+            buffer += head
+            guard let tag = leadingTag(in: rest[index...], open: "<", close: ">"),
+                  let millis = milliseconds(tag.body) else {
+                // Not a timing tag: a literal "<" belongs to the lyrics.
+                text.append("<")
+                buffer.append("<")
+                rest = rest[rest.index(after: index)...]
+                continue
+            }
+            flush()
+            pendingStart = millis
+            rest = tag.remainder
+        }
+
+        text += rest
+        buffer += rest
+        flush()
+
+        return (text, words)
+    }
+
+    /// Each word ends where the next one starts; the last ends with the line.
+    private static func closeOpenEnds(_ words: [TimedWord], lineEnd: Int?) -> [TimedWord] {
+        words.enumerated().map { index, word in
+            let next = index + 1 < words.count ? words[index + 1].start : lineEnd
+            return TimedWord(value: word.value, start: word.start, end: max(word.start, next ?? word.start))
+        }
+    }
+
+    /// `mm:ss`, `mm:ss.xx` (hundredths) or `mm:ss.xxx` (thousandths).
+    private static func milliseconds(_ tag: String) -> Int? {
+        let parts = tag.split(separator: ":")
+        guard parts.count == 2, let minutes = Int(parts[0]) else { return nil }
+
+        let secondsPart = parts[1].split(whereSeparator: { $0 == "." || $0 == ":" })
+        guard let seconds = Int(secondsPart.first ?? ""), seconds >= 0 else { return nil }
+
+        var fraction = 0
+        if secondsPart.count > 1 {
+            let digits = secondsPart[1]
+            guard let value = Int(digits) else { return nil }
+            switch digits.count {
+            case 1: fraction = value * 100
+            case 2: fraction = value * 10
+            case 3: fraction = value
+            default: return nil
+            }
+        }
+        return minutes * 60_000 + seconds * 1_000 + fraction
+    }
+
+    private static func timestamp(_ millis: Int) -> String {
+        let total = max(0, millis)
+        return String(format: "%02d:%02d.%03d", total / 60_000, (total / 1_000) % 60, total % 1_000)
+    }
+}
+
+/// Which word is being sung, and how far the line has swept.
+nonisolated enum LyricsKaraokeTiming {
+    /// The word being sung at `millis`, or nil before the line starts or when
+    /// the line carries no word timing.
+    ///
+    /// After the last word the highlight stays on it rather than clearing: the
+    /// alternative blinks off in the gap before the next line.
+    static func activeWordIndex(in line: TimedLyricLine, at millis: Int) -> Int? {
+        guard let first = line.words.first, millis >= first.start else { return nil }
+        return line.words.lastIndex { $0.start <= millis }
+    }
+
+    /// 0 before the line, 1 once it is over, sweeping in between. Drives the
+    /// fill of the active line without a per-word animation.
+    static func progress(in line: TimedLyricLine, at millis: Int) -> Double {
+        guard let first = line.words.first, let last = line.words.last else { return 0 }
+        let span = last.end - first.start
+        guard span > 0 else { return millis >= first.start ? 1 : 0 }
+        return min(1, max(0, Double(millis - first.start) / Double(span)))
+    }
+}

--- a/ShelvCore/Services/LyricsService.swift
+++ b/ShelvCore/Services/LyricsService.swift
@@ -570,7 +570,15 @@ actor LyricsService {
 
     private func fetchFromNavidrome(song: Song, serverId: String) async -> LyricsRecord? {
         DBErrorLog.logLyrics("Request → Navidrome: \(song.title)")
-        guard let entry = try? await SubsonicAPIService.shared.getLyricsBySongId(songId: song.id),
+        // Word timing is only asked for when the server says it can answer:
+        // older servers do not know the `enhanced` parameter.
+        let capabilities = await SubsonicAPIService.shared.openSubsonicCapabilities()
+        let wantsWordTiming = capabilities.supports(OpenSubsonicExtension.songLyrics, version: 2)
+
+        guard let entry = try? await SubsonicAPIService.shared.getLyricsBySongId(
+                songId: song.id,
+                enhanced: wantsWordTiming
+              ),
               let lines = entry.line, !lines.isEmpty else {
             DBErrorLog.logLyrics("No match → Navidrome: \(song.title)")
             return nil
@@ -581,14 +589,13 @@ actor LyricsService {
 
         var lrc: String? = nil
         if entry.synced {
-            let lrcLines = lines.compactMap { line -> String? in
-                guard let ms = line.start else { return nil }
-                let min = (ms / 1000) / 60
-                let sec = (ms / 1000) % 60
-                let cs  = (ms % 1000) / 10
-                return String(format: "[%02d:%02d.%02d] %@", min, sec, cs, line.value)
+            // Enhanced LRC is a superset of LRC, so a track without word timing
+            // still comes out as an ordinary [mm:ss.xxx] file.
+            let timed = entry.timedLines
+            lrc = timed.isEmpty ? nil : EnhancedLyricsParser.serialize(timed)
+            if timed.contains(where: \.hasWordTiming) {
+                DBErrorLog.logLyrics("Word timing → Navidrome: \(song.title)")
             }
-            lrc = lrcLines.isEmpty ? nil : lrcLines.joined(separator: "\n")
         }
 
         return LyricsRecord(

--- a/ShelvCore/Services/SubsonicAPIService.swift
+++ b/ShelvCore/Services/SubsonicAPIService.swift
@@ -2509,12 +2509,28 @@ nonisolated class SubsonicAPIService: ObservableObject, @unchecked Sendable {
 
     // MARK: - Lyrics (OpenSubsonic)
 
-    func getLyricsBySongId(songId: String) async throws -> StructuredLyrics? {
-        let body = try await fetchDecoded(Envelope<LyricsListBody>.self, path: "getLyricsBySongId", extra: [
-            URLQueryItem(name: "id", value: songId)
-        ]).response
+    /// - Parameter enhanced: asks for word and syllable timing. Only send it
+    ///   when the server advertises `songLyrics` version 2; older servers do
+    ///   not know the parameter.
+    func getLyricsBySongId(songId: String, enhanced: Bool = false) async throws -> StructuredLyrics? {
+        var extra = [URLQueryItem(name: "id", value: songId)]
+        if enhanced {
+            extra.append(URLQueryItem(name: "enhanced", value: "true"))
+        }
+        let body = try await fetchDecoded(
+            Envelope<LyricsListBody>.self,
+            path: "getLyricsBySongId",
+            extra: extra
+        ).response
         try check(status: body.status, error: body.error)
-        return body.lyricsList?.structuredLyrics?.first
+        return Self.preferredLyrics(body.lyricsList?.structuredLyrics)
+    }
+
+    /// With v2 a server can return the main lyrics alongside a translation and
+    /// a pronunciation. Taking the first would show whichever came first.
+    nonisolated static func preferredLyrics(_ all: [StructuredLyrics]?) -> StructuredLyrics? {
+        guard let all, !all.isEmpty else { return nil }
+        return all.first(where: \.isMain) ?? all.first
     }
 
     /// URL für getLyricsBySongId — nutzbar mit Background-URLSession.
@@ -2535,7 +2551,7 @@ nonisolated class SubsonicAPIService: ObservableObject, @unchecked Sendable {
             from: data
         ).response {
             guard body.status != "failed" else { return nil }
-            return body.lyricsList?.structuredLyrics?.first
+            return Self.preferredLyrics(body.lyricsList?.structuredLyrics)
         }
         guard let body = try? SubsonicXMLDecoder().decode(
             Envelope<LyricsListBody>.self,
@@ -2550,10 +2566,57 @@ nonisolated struct StructuredLyrics: Codable, Sendable {
     let synced: Bool
     let lang: String?
     let line: [LyricsLine]?
+    /// Milliseconds to shift every timestamp by. OpenSubsonic, optional.
+    let offset: Int?
+    /// `main`, `translation` or `pronunciation`. OpenSubsonic v2, optional.
+    let kind: String?
+    /// Word and syllable timing, returned only when `enhanced=true` was sent
+    /// and the server advertises `songLyrics` version 2.
+    let cueLine: [CueLine]?
 
     struct LyricsLine: Codable, Sendable {
         let start: Int?
         let value: String
+    }
+
+    struct CueLine: Codable, Sendable {
+        let index: Int?
+        let start: Int?
+        let end: Int?
+        let value: String?
+        let cue: [Cue]?
+
+        struct Cue: Codable, Sendable {
+            let start: Int?
+            let end: Int?
+            let value: String?
+        }
+    }
+
+    var isMain: Bool { kind == nil || kind == "main" }
+
+    /// Lines with word timing where the server provided it, ready for the
+    /// Enhanced LRC writer. Falls back to line-level timing per line.
+    var timedLines: [TimedLyricLine] {
+        let shift = offset ?? 0
+        let cues = Dictionary(
+            (cueLine ?? []).enumerated().map { ($1.index ?? $0, $1) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        return (line ?? []).enumerated().compactMap { index, entry in
+            guard let start = entry.start else { return nil }
+            let words = (cues[index]?.cue ?? []).compactMap { cue -> TimedWord? in
+                guard let cueStart = cue.start, let value = cue.value else { return nil }
+                let trimmed = value.trimmingCharacters(in: .whitespaces)
+                guard !trimmed.isEmpty else { return nil }
+                return TimedWord(
+                    value: trimmed,
+                    start: cueStart + shift,
+                    end: (cue.end ?? cueStart) + shift
+                )
+            }
+            return TimedLyricLine(start: start + shift, text: entry.value, words: words)
+        }
     }
 }
 

--- a/ShelvCore/Services/SubsonicAPIService.swift
+++ b/ShelvCore/Services/SubsonicAPIService.swift
@@ -191,7 +191,19 @@ private nonisolated struct PingInfoBody: Decodable, Sendable {
     let version: String
     let type: String?
     let serverVersion: String?
+    let openSubsonic: Bool?
     let error: StatusCheck.APIError?
+}
+
+private nonisolated struct OpenSubsonicExtensionsBody: Decodable, Sendable {
+    let status: String
+    let error: StatusCheck.APIError?
+    let openSubsonicExtensions: [Extension]?
+
+    struct Extension: Decodable, Sendable {
+        let name: String
+        let versions: [Int]?
+    }
 }
 
 private nonisolated struct GetUserBody: Decodable, Sendable {
@@ -453,6 +465,11 @@ nonisolated class SubsonicAPIService: ObservableObject, @unchecked Sendable {
 
     private let credentialLock = NSLock()
     private let compatibilityLock = NSLock()
+    private let capabilityLock = NSLock()
+    /// OpenSubsonic extensions per server, learned at connection time and kept
+    /// for the session only: a server that gets upgraded should be re-probed on
+    /// the next launch rather than remembered as it was months ago.
+    nonisolated(unsafe) private var _openSubsonicCapabilities: [String: OpenSubsonicCapabilities] = [:]
     nonisolated(unsafe) private var _activeServer: SubsonicServer?
     nonisolated(unsafe) private var _activePassword: String?
     nonisolated(unsafe) private var _credentialGeneration: UInt64 = 0
@@ -1285,7 +1302,85 @@ nonisolated class SubsonicAPIService: ObservableObject, @unchecked Sendable {
             responseFormatServerFingerprint(info),
             serverKey: responseFormatServerKey(for: server)
         )
+        // Connecting is the natural moment to learn what the server implements.
+        // A server that answers `openSubsonic: false`, or no flag at all, is a
+        // classic Subsonic server and must never be asked for an extension.
+        if body.openSubsonic == true {
+            await refreshOpenSubsonicCapabilities(server: server, password: password)
+        } else {
+            storeOpenSubsonicCapabilities(.none, for: server)
+        }
         return info
+    }
+
+    /// What the given server advertised through `getOpenSubsonicExtensions`.
+    ///
+    /// Returns `.none` until the server has been probed, which is deliberate:
+    /// an un-probed server must be treated as a classic Subsonic server rather
+    /// than optimistically called with extension-only parameters.
+    nonisolated func openSubsonicCapabilities(for server: SubsonicServer) -> OpenSubsonicCapabilities {
+        capabilityLock.withLock {
+            _openSubsonicCapabilities[responseFormatServerKey(for: server)] ?? .none
+        }
+    }
+
+    /// Capabilities of the server currently in use, probing it once if the app
+    /// has not connected through `ping(server:password:)` in this session.
+    func openSubsonicCapabilities() async -> OpenSubsonicCapabilities {
+        guard let credentials = try? await resolveCredentials() else { return .none }
+        let key = responseFormatServerKey(for: credentials.server)
+        if let known = capabilityLock.withLock({ _openSubsonicCapabilities[key] }) {
+            return known
+        }
+        await refreshOpenSubsonicCapabilities(
+            server: credentials.server,
+            password: credentials.password
+        )
+        return openSubsonicCapabilities(for: credentials.server)
+    }
+
+    /// Asks the server what it implements. Never throws: a server that does not
+    /// know the endpoint answers with an API error or a 404, and that is simply
+    /// the answer "nothing", not a failure worth surfacing to the listener.
+    private func refreshOpenSubsonicCapabilities(server: SubsonicServer, password: String) async {
+        let capabilities: OpenSubsonicCapabilities
+        do {
+            capabilities = try await getOpenSubsonicExtensions(server: server, password: password)
+        } catch {
+            capabilities = .none
+        }
+        storeOpenSubsonicCapabilities(capabilities, for: server)
+    }
+
+    nonisolated private func storeOpenSubsonicCapabilities(
+        _ capabilities: OpenSubsonicCapabilities,
+        for server: SubsonicServer
+    ) {
+        let key = responseFormatServerKey(for: server)
+        capabilityLock.withLock { _openSubsonicCapabilities[key] = capabilities }
+    }
+
+    func getOpenSubsonicExtensions(
+        server: SubsonicServer,
+        password: String
+    ) async throws -> OpenSubsonicCapabilities {
+        #if DEBUG
+        if server.baseURL == DemoContent.serverBaseURL || server.activeBaseURL == DemoContent.serverBaseURL {
+            return .none
+        }
+        #endif
+        let body = try await fetchDecoded(
+            Envelope<OpenSubsonicExtensionsBody>.self,
+            for: server,
+            password: password,
+            path: "getOpenSubsonicExtensions"
+        ).response
+        try check(status: body.status, error: body.error)
+        return OpenSubsonicCapabilities(
+            advertised: (body.openSubsonicExtensions ?? []).map {
+                (name: $0.name, versions: $0.versions ?? [1])
+            }
+        )
     }
 
     /// Whether the given credentials have admin rights on the server. Some operations

--- a/ShelvCore/Support/OpenSubsonicCapabilities.swift
+++ b/ShelvCore/Support/OpenSubsonicCapabilities.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// Names of the OpenSubsonic extensions Shelv knows how to take advantage of.
+///
+/// Servers advertise what they implement through `getOpenSubsonicExtensions`.
+/// Anything not advertised must not be called: classic Subsonic servers answer
+/// those endpoints with an error, and Navidrome returns 404 for an extension
+/// whose backing plugin is missing.
+nonisolated enum OpenSubsonicExtension {
+    /// Structured lyrics. Version 2 adds word and syllable timing behind `enhanced=true`.
+    static let songLyrics = "songLyrics"
+    /// Audio similarity: `getSonicSimilarTracks` and `findSonicPath`.
+    static let sonicSimilarity = "sonicSimilarity"
+    /// `getTopSongs` accepts an artist id rather than a name.
+    static let topSongsByArtistId = "topSongsByArtistId"
+    /// Credentials sent as an API key instead of an MD5 of salt and password.
+    static let apiKeyAuthentication = "apiKeyAuthentication"
+    /// Seeking inside a transcoded stream.
+    static let transcodeOffset = "transcodeOffset"
+    /// Credentials sent in a form body instead of the query string.
+    static let formPost = "formPost"
+}
+
+/// What one server advertised, with the versions it supports per extension.
+nonisolated struct OpenSubsonicCapabilities: Equatable, Sendable {
+    /// A server that advertised nothing, or was never asked. Supports nothing.
+    static let none = OpenSubsonicCapabilities(extensions: [:])
+
+    private let extensions: [String: Set<Int>]
+
+    init(extensions: [String: Set<Int>]) {
+        self.extensions = extensions
+    }
+
+    init(advertised: [(name: String, versions: [Int])]) {
+        // A server may repeat a name; merge rather than let the last one win.
+        self.extensions = advertised.reduce(into: [:]) { result, entry in
+            result[entry.name, default: []].formUnion(entry.versions)
+        }
+    }
+
+    /// True when the server implements `name` at `version` or better.
+    ///
+    /// Versions are independent numbers rather than a range, so a server that
+    /// advertises only version 2 still answers version 1 requests: the spec
+    /// requires later versions to stay backwards compatible.
+    func supports(_ name: String, version: Int = 1) -> Bool {
+        guard let versions = extensions[name] else { return false }
+        return versions.contains { $0 >= version }
+    }
+
+    var isEmpty: Bool { extensions.isEmpty }
+}

--- a/ShelvTests/EnhancedLyricsTests.swift
+++ b/ShelvTests/EnhancedLyricsTests.swift
@@ -1,0 +1,121 @@
+import XCTest
+
+final class EnhancedLyricsParserTests: XCTestCase {
+    func testPlainTimedLinesParseWithoutWordTiming() {
+        let lrc = """
+        [00:12.00]The quick brown fox
+        [00:15.50]jumps over the lazy dog
+        """
+
+        let lines = EnhancedLyricsParser.parse(lrc)
+
+        XCTAssertEqual(lines.count, 2)
+        XCTAssertEqual(lines[0].start, 12_000)
+        XCTAssertEqual(lines[0].text, "The quick brown fox")
+        XCTAssertTrue(lines[0].words.isEmpty)
+        XCTAssertEqual(lines[1].start, 15_500)
+    }
+
+    func testWordTagsProduceWordTiming() {
+        let lrc = "[00:12.00]<00:12.00>The <00:12.50>quick <00:13.00>fox"
+
+        let lines = EnhancedLyricsParser.parse(lrc)
+
+        XCTAssertEqual(lines.count, 1)
+        // The visible text keeps its spacing and drops every tag.
+        XCTAssertEqual(lines[0].text, "The quick fox")
+        XCTAssertEqual(lines[0].words.map(\.value), ["The", "quick", "fox"])
+        XCTAssertEqual(lines[0].words.map(\.start), [12_000, 12_500, 13_000])
+        // A word ends where the next one starts.
+        XCTAssertEqual(lines[0].words[0].end, 12_500)
+        XCTAssertEqual(lines[0].words[1].end, 13_000)
+    }
+
+    func testTheLastWordOfALineEndsWhenTheNextLineStarts() {
+        let lrc = """
+        [00:10.00]<00:10.00>one <00:11.00>two
+        [00:14.00]<00:14.00>three
+        """
+
+        let lines = EnhancedLyricsParser.parse(lrc)
+
+        XCTAssertEqual(lines[0].words.last?.end, 14_000)
+    }
+
+    func testMetadataTagsAndBlankLinesAreIgnored() {
+        let lrc = """
+        [ar:Someone]
+        [ti:A song]
+
+        [00:05.00]only line
+        """
+
+        let lines = EnhancedLyricsParser.parse(lrc)
+
+        XCTAssertEqual(lines.map(\.text), ["only line"])
+    }
+
+    func testMillisecondTagsAreAccepted() {
+        // LRCLIB writes hundredths, Navidrome's ELRC export writes thousandths.
+        XCTAssertEqual(EnhancedLyricsParser.parse("[01:02.345]x").first?.start, 62_345)
+        XCTAssertEqual(EnhancedLyricsParser.parse("[01:02.34]x").first?.start, 62_340)
+    }
+
+    func testLinesAreSortedByStartEvenWhenTheFileIsNot() {
+        let lines = EnhancedLyricsParser.parse("[00:20.00]second\n[00:10.00]first")
+
+        XCTAssertEqual(lines.map(\.text), ["first", "second"])
+    }
+
+    func testSerializingRoundTripsThroughTheParser() {
+        let original = [
+            TimedLyricLine(start: 10_000, text: "one two", words: [
+                TimedWord(value: "one", start: 10_000, end: 10_500),
+                TimedWord(value: "two", start: 10_500, end: 12_000)
+            ]),
+            TimedLyricLine(start: 12_000, text: "three", words: [])
+        ]
+
+        let reparsed = EnhancedLyricsParser.parse(EnhancedLyricsParser.serialize(original))
+
+        XCTAssertEqual(reparsed.map(\.text), ["one two", "three"])
+        XCTAssertEqual(reparsed[0].words.map(\.value), ["one", "two"])
+        XCTAssertEqual(reparsed[0].words.map(\.start), [10_000, 10_500])
+    }
+}
+
+final class LyricsKaraokeTimingTests: XCTestCase {
+    private let line = TimedLyricLine(start: 10_000, text: "one two", words: [
+        TimedWord(value: "one", start: 10_000, end: 11_000),
+        TimedWord(value: "two", start: 11_000, end: 12_000)
+    ])
+
+    func testNoWordIsActiveBeforeTheLineStarts() {
+        XCTAssertNil(LyricsKaraokeTiming.activeWordIndex(in: line, at: 9_999))
+    }
+
+    func testTheWordBeingSungIsTheActiveOne() {
+        XCTAssertEqual(LyricsKaraokeTiming.activeWordIndex(in: line, at: 10_000), 0)
+        XCTAssertEqual(LyricsKaraokeTiming.activeWordIndex(in: line, at: 10_999), 0)
+        XCTAssertEqual(LyricsKaraokeTiming.activeWordIndex(in: line, at: 11_000), 1)
+    }
+
+    func testTheLastWordStaysActiveOnceTheLineIsOver() {
+        // Otherwise the highlight would blink off between the last word and the
+        // next line, which is exactly the transition problem raised in #10.
+        XCTAssertEqual(LyricsKaraokeTiming.activeWordIndex(in: line, at: 99_000), 1)
+    }
+
+    func testProgressSweepsAcrossTheWholeLine() {
+        XCTAssertEqual(LyricsKaraokeTiming.progress(in: line, at: 9_000), 0, accuracy: 0.001)
+        XCTAssertEqual(LyricsKaraokeTiming.progress(in: line, at: 11_000), 0.5, accuracy: 0.001)
+        XCTAssertEqual(LyricsKaraokeTiming.progress(in: line, at: 12_000), 1, accuracy: 0.001)
+        XCTAssertEqual(LyricsKaraokeTiming.progress(in: line, at: 99_000), 1, accuracy: 0.001)
+    }
+
+    func testALineWithoutWordTimingHasNoKaraokeState() {
+        let plain = TimedLyricLine(start: 0, text: "x", words: [])
+        XCTAssertNil(LyricsKaraokeTiming.activeWordIndex(in: plain, at: 5))
+        XCTAssertEqual(LyricsKaraokeTiming.progress(in: plain, at: 5), 0, accuracy: 0.001)
+    }
+}

--- a/ShelvTests/OpenSubsonicCapabilitiesTests.swift
+++ b/ShelvTests/OpenSubsonicCapabilitiesTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+
+final class OpenSubsonicCapabilitiesTests: XCTestCase {
+    func testAServerThatWasNeverAskedSupportsNothing() {
+        XCTAssertFalse(OpenSubsonicCapabilities.none.supports(OpenSubsonicExtension.songLyrics))
+        XCTAssertTrue(OpenSubsonicCapabilities.none.isEmpty)
+    }
+
+    func testAdvertisedExtensionsAreMatchedByNameAndVersion() {
+        let caps = OpenSubsonicCapabilities(advertised: [
+            (name: OpenSubsonicExtension.songLyrics, versions: [1, 2]),
+            (name: OpenSubsonicExtension.transcodeOffset, versions: [1])
+        ])
+
+        XCTAssertTrue(caps.supports(OpenSubsonicExtension.songLyrics))
+        XCTAssertTrue(caps.supports(OpenSubsonicExtension.songLyrics, version: 2))
+        XCTAssertTrue(caps.supports(OpenSubsonicExtension.transcodeOffset))
+        XCTAssertFalse(caps.supports(OpenSubsonicExtension.transcodeOffset, version: 2))
+        XCTAssertFalse(caps.supports(OpenSubsonicExtension.sonicSimilarity))
+    }
+
+    func testALaterVersionSatisfiesAnEarlierRequirement() {
+        // The spec requires later versions to stay backwards compatible, so a
+        // server advertising only v2 still answers a v1 request.
+        let caps = OpenSubsonicCapabilities(advertised: [
+            (name: OpenSubsonicExtension.songLyrics, versions: [2])
+        ])
+
+        XCTAssertTrue(caps.supports(OpenSubsonicExtension.songLyrics, version: 1))
+        XCTAssertTrue(caps.supports(OpenSubsonicExtension.songLyrics, version: 2))
+        XCTAssertFalse(caps.supports(OpenSubsonicExtension.songLyrics, version: 3))
+    }
+
+    func testARepeatedNameMergesItsVersionsInsteadOfOverwriting() {
+        let caps = OpenSubsonicCapabilities(advertised: [
+            (name: OpenSubsonicExtension.songLyrics, versions: [1]),
+            (name: OpenSubsonicExtension.songLyrics, versions: [2])
+        ])
+
+        XCTAssertTrue(caps.supports(OpenSubsonicExtension.songLyrics, version: 2))
+    }
+}


### PR DESCRIPTION
**Stacked on #39.** The branch is now linear and split at the boundary: the first two commits are #39 exactly as it stands, the last two are this PR. Review from `f63b6f9`.

GitHub still shows #39's four files in the diff below, because both PRs target `main` from the same fork and there is no way to base one on the other. Merge #39 and this diff drops to nine files, +456/-214, all lyrics.

On #10 you said you would keep LRCLIB as the only external service, but that if word-by-word data is present the lyrics view would adjust. That data now exists, from the server, with no extra service.

- **OpenSubsonic v2 lyrics** adds an `enhanced=true` parameter to `getLyricsBySongId` and a `cueLine` array with per-word or per-syllable `start` / `end`, plus `kind` (main / translation / pronunciation) and an `agents` array for multi-voice tracks.
- **Navidrome 0.63** parses TTML, ELRC, SRT and YAML sidecar files with word-by-word timing and exposes them through exactly those extensions.

Shelv sends only `id` on that call, so it always receives the v1 line-level answer, even from a server holding the word timing on disk.

## The transition problem you raised

You wrote that a line lasting ten seconds but sung for five breaks the animation, because line timestamps are all we have. That is what `cueLine` fixes: the sweep follows real word timings instead of interpolating across the line. A track with no word data behaves exactly as today.

## What this does

1. `enhanced=true` goes out only when the `songLyrics` v2 extension is advertised.
2. Word timings are written into the existing `syncedLrc` column as **Enhanced LRC**, a superset of LRC. No schema change, no second column, and anyone whose server already serves ELRC gets it too.
3. `kind` is respected. With v2 a server can return the main lyrics, a translation and a pronunciation in one response; taking `.first` would show whichever came first.
4. Only the active line reads the playback clock, so the stack does not re-render on every tick.

## Four LRC parsers became one

iOS, macOS and tvOS each had a private, untested regex parser plus its own `stripLRCTimestamps`, none of which know word tags — they would have printed `<00:12.00>` as visible text once ELRC reached the database. All six now go through `EnhancedLyricsParser`, covered by 12 tests. **Net -73 lines.**

## Question

The word-level highlight is wired into the **native** lyrics style only, since that is the one you said follows Apple. Should the standard style get it too, or stay line-level on purpose?

## Verification

Green on all three targets: 479 tests on iOS 26.5 (iPhone 17 Pro), 483 on macOS, no failures, 12 of them new across `EnhancedLyricsParserTests` and `LyricsKaraokeTimingTests`. `Shelv TV` builds against the tvOS 26.5 simulator, so the tvOS side of this change is compiled now rather than parsed — #46 landing is what made that possible.

