### PR TITLE
fix: move the latest release card above the sort control on macOS

### DIFF
--- a/Shelv Mac/Views/ArtistDetailView.swift
+++ b/Shelv Mac/Views/ArtistDetailView.swift
@@ -190,6 +190,11 @@ struct ArtistDetailView: View {
                                 }
                                 .padding(.horizontal, 20)
 
+                                if isGrid, let latestRelease {
+                                    // The card pads itself (24pt), so none here.
+                                    ArtistLatestReleaseCard(album: latestRelease, accentColor: themeColor)
+                                }
+
                                 HStack(spacing: 8) {
                                     Picker(String(localized: "sort"), selection: $sortRaw) {
                                         ForEach(LibrarySortOption.allCases.filter {
@@ -225,9 +230,6 @@ struct ArtistDetailView: View {
 
                             if isGrid && searchQuery.isEmpty {
                                 VStack(alignment: .leading, spacing: 24) {
-                                    if let latestRelease {
-                                        ArtistLatestReleaseCard(album: latestRelease, accentColor: themeColor)
-                                    }
                                     if !albumsOnly.isEmpty {
                                         ArtistReleaseShelf(
                                             title: String(localized: "albums"),


### PR DESCRIPTION
On the macOS artist page the discography header is followed by the sort control, and the Latest Release card comes after both.

Sorting never touches that card. Switch to "Most played" and it stays where it is, still showing the newest release. Its position promises a relationship that does not exist.

Moving the card above the sort row removes the ambiguity: everything the sort control governs sits below it, and nothing above.

The card still shows in grid mode only, and the spacing is unchanged — the enclosing stack already uses the same 24pt the card had inside the grid stack.

iOS is not affected: the card is already first there, and the sort lives in the toolbar menu rather than inline.

One file, +5 / -3.

## Verification

macOS builds. iOS untouched, its 459 tests still pass.

## Note

Conflicts with `fix/artist-page-partial-albums` in the same region of `Shelv Mac/Views/ArtistDetailView.swift`. Whichever you merge first, I will rebase the other.

## Heads-up on the test suite

`SubsonicResponseCompatibilityTests.testIdenticalFallbackRequestsAreCoalesced()` is flaky on `main` itself: I ran it 10 times on a detached `origin/main` (6b5ea29) with no changes and it failed twice. It races two `async let` requests and assumes the first registers in the gate before the second arrives, which does not hold under load. Mentioning it so a red run on this PR is not mistaken for my doing — happy to open a separate issue if useful.
