### PR TITLE
feat: play the top songs first from the artist page

### DIFF
--- a/Shelv Mac/Views/ArtistDetailView.swift
+++ b/Shelv Mac/Views/ArtistDetailView.swift
@@ -855,8 +855,16 @@ class ArtistDetailViewModel: ObservableObject {
     func playAll(player: AudioPlayerService, albums: [Album], shuffle: Bool) async {
         var songs = await fetchSongs(albums: albums)
         guard !songs.isEmpty else { return }
-        if songs.count > maxSongs { songs = Array(songs.shuffled().prefix(maxSongs)) }
-        if shuffle { player.playShuffled(songs: songs) } else { player.play(songs: songs) }
+        if shuffle {
+            // Shuffling already discards the order, so sample at random.
+            if songs.count > maxSongs { songs = Array(songs.shuffled().prefix(maxSongs)) }
+            player.playShuffled(songs: songs)
+        } else {
+            songs = ArtistPlayOrder.songs(topSongs: topSongs, discography: songs)
+            // Trim from the end so the top songs survive the cap.
+            if songs.count > maxSongs { songs = Array(songs.prefix(maxSongs)) }
+            player.play(songs: songs)
+        }
     }
 }
 

--- a/Shelv TV/Views/Library/ArtistDetailView.swift
+++ b/Shelv TV/Views/Library/ArtistDetailView.swift
@@ -184,7 +184,10 @@ struct ArtistDetailView: View {
             Text(artistSubtitle)
                 .font(.callout).foregroundStyle(.secondary)
             HStack(spacing: 20) {
-                Button { player.play(songs: songs, startIndex: 0) } label: {
+                Button {
+                    let ordered = ArtistPlayOrder.songs(topSongs: topSongs, discography: songs)
+                    player.play(songs: ordered, startIndex: 0)
+                } label: {
                     Label(String(localized: "play"), systemImage: "play.fill")
                 }
                 .disabled(songs.isEmpty)

--- a/Shelv.xcodeproj/project.pbxproj
+++ b/Shelv.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		BC1001502FFE000000000001 /* ShelvCore/Services/SubsonicResponseCompatibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1001512FFE000000000001 /* ShelvCore/Services/SubsonicResponseCompatibility.swift */; };
 		BC1001522FFE000000000001 /* ShelvCore/Stores/SearchHistoryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1001532FFE000000000001 /* ShelvCore/Stores/SearchHistoryStore.swift */; };
 		BC1001542FFE000000000001 /* ShelvCore/Support/AlphabetIndexSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1001552FFE000000000001 /* ShelvCore/Support/AlphabetIndexSelection.swift */; };
+		BBF091A70FDE00000000C0DE /* ShelvCore/Services/ArtistPlayOrder.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF091A70FDE00000000C0DE /* ShelvCore/Services/ArtistPlayOrder.swift */; };
 		BC1001602FFE000000000001 /* ShelvCore/Services/InfinityMixPoolBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1001612FFE000000000001 /* ShelvCore/Services/InfinityMixPoolBuilder.swift */; };
 		BC1867E52F91A088006D96E2 /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = BC1867E42F91A088006D96E2 /* GRDB */; };
 		BC51161D2FDC8A850011CDE9 /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = BC51161C2FDC8A850011CDE9 /* GRDB */; };
@@ -140,6 +141,7 @@
 		BC1001512FFE000000000001 /* ShelvCore/Services/SubsonicResponseCompatibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/SubsonicResponseCompatibility.swift; sourceTree = "<group>"; };
 		BC1001532FFE000000000001 /* ShelvCore/Stores/SearchHistoryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Stores/SearchHistoryStore.swift; sourceTree = "<group>"; };
 		BC1001552FFE000000000001 /* ShelvCore/Support/AlphabetIndexSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Support/AlphabetIndexSelection.swift; sourceTree = "<group>"; };
+		AAF091A70FDE00000000C0DE /* ShelvCore/Services/ArtistPlayOrder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/ArtistPlayOrder.swift; sourceTree = "<group>"; };
 		BC1001612FFE000000000001 /* ShelvCore/Services/InfinityMixPoolBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/InfinityMixPoolBuilder.swift; sourceTree = "<group>"; };
 		BC2000012FFE000000000001 /* ShelvAppIntentsUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ShelvAppIntentsUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BC5116112FDC8A690011CDE9 /* Shelv TV.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Shelv TV.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -312,6 +314,7 @@
 				BC1001512FFE000000000001 /* ShelvCore/Services/SubsonicResponseCompatibility.swift */,
 				BC1001532FFE000000000001 /* ShelvCore/Stores/SearchHistoryStore.swift */,
 				BC1001552FFE000000000001 /* ShelvCore/Support/AlphabetIndexSelection.swift */,
+				AAF091A70FDE00000000C0DE /* ShelvCore/Services/ArtistPlayOrder.swift */,
 				BC10014D2FFE000000000001 /* ShelvCore/Stores/DownloadUIStateHub.swift */,
 			);
 			name = "ShelvCore Test Sources";
@@ -663,6 +666,7 @@
 				BC1001502FFE000000000001 /* ShelvCore/Services/SubsonicResponseCompatibility.swift in Sources */,
 				BC1001522FFE000000000001 /* ShelvCore/Stores/SearchHistoryStore.swift in Sources */,
 				BC1001542FFE000000000001 /* ShelvCore/Support/AlphabetIndexSelection.swift in Sources */,
+				BBF091A70FDE00000000C0DE /* ShelvCore/Services/ArtistPlayOrder.swift in Sources */,
 				BC10014C2FFE000000000001 /* ShelvCore/Stores/DownloadUIStateHub.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Shelv.xcodeproj/project.pbxproj
+++ b/Shelv.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		11F3AAFBB4684ECFABA0E3E5 /* ShelvCore/Models/RecapPeriod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3481C1649E04481CA0F35E60 /* ShelvCore/Models/RecapPeriod.swift */; };
 		4B666BEAD970D72DFCFF9C7E /* ShelvCore/Services/RadioStationChangeLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8C9F16F5098EE7158A393F2 /* ShelvCore/Services/RadioStationChangeLogic.swift */; };
 		4C9CE80450C542811BFC06B9 /* ShelvCore/Services/ArtistTopSongsRanking.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2D3956FCB8E5BA0EA7B365B /* ShelvCore/Services/ArtistTopSongsRanking.swift */; };
+		BBF091A70FDE00000000C0DE /* ShelvCore/Services/ArtistPlayOrder.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF091A70FDE00000000C0DE /* ShelvCore/Services/ArtistPlayOrder.swift */; };
 		54755D0F4F7624D1CB2AFAA0 /* ShelvCore/Services/RemoteStreamFailureRetryPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D76D0722C024A55F5646646B /* ShelvCore/Services/RemoteStreamFailureRetryPolicy.swift */; };
 		767C48F98385493A929D3CF5 /* ShelvCore/Services/PlaylistDuplicateChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7032627BABC540CC8752182E /* ShelvCore/Services/PlaylistDuplicateChecker.swift */; };
 		A3BC3F4796D89CE06D73AEBA /* ShelvCore/Services/ArtistDiscography.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFBB0EAEC930A6AA93845AF6 /* ShelvCore/Services/ArtistDiscography.swift */; };
@@ -55,7 +56,6 @@
 		BC1001502FFE000000000001 /* ShelvCore/Services/SubsonicResponseCompatibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1001512FFE000000000001 /* ShelvCore/Services/SubsonicResponseCompatibility.swift */; };
 		BC1001522FFE000000000001 /* ShelvCore/Stores/SearchHistoryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1001532FFE000000000001 /* ShelvCore/Stores/SearchHistoryStore.swift */; };
 		BC1001542FFE000000000001 /* ShelvCore/Support/AlphabetIndexSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1001552FFE000000000001 /* ShelvCore/Support/AlphabetIndexSelection.swift */; };
-		BBF091A70FDE00000000C0DE /* ShelvCore/Services/ArtistPlayOrder.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF091A70FDE00000000C0DE /* ShelvCore/Services/ArtistPlayOrder.swift */; };
 		BC1001602FFE000000000001 /* ShelvCore/Services/InfinityMixPoolBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1001612FFE000000000001 /* ShelvCore/Services/InfinityMixPoolBuilder.swift */; };
 		BC1867E52F91A088006D96E2 /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = BC1867E42F91A088006D96E2 /* GRDB */; };
 		BC51161D2FDC8A850011CDE9 /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = BC51161C2FDC8A850011CDE9 /* GRDB */; };
@@ -141,7 +141,6 @@
 		BC1001512FFE000000000001 /* ShelvCore/Services/SubsonicResponseCompatibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/SubsonicResponseCompatibility.swift; sourceTree = "<group>"; };
 		BC1001532FFE000000000001 /* ShelvCore/Stores/SearchHistoryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Stores/SearchHistoryStore.swift; sourceTree = "<group>"; };
 		BC1001552FFE000000000001 /* ShelvCore/Support/AlphabetIndexSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Support/AlphabetIndexSelection.swift; sourceTree = "<group>"; };
-		AAF091A70FDE00000000C0DE /* ShelvCore/Services/ArtistPlayOrder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/ArtistPlayOrder.swift; sourceTree = "<group>"; };
 		BC1001612FFE000000000001 /* ShelvCore/Services/InfinityMixPoolBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/InfinityMixPoolBuilder.swift; sourceTree = "<group>"; };
 		BC2000012FFE000000000001 /* ShelvAppIntentsUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ShelvAppIntentsUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BC5116112FDC8A690011CDE9 /* Shelv TV.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Shelv TV.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -153,6 +152,7 @@
 		D76D0722C024A55F5646646B /* ShelvCore/Services/RemoteStreamFailureRetryPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/RemoteStreamFailureRetryPolicy.swift; sourceTree = "<group>"; };
 		DB776033CC96417A93CA66DB /* ShelvCore/Services/ConcurrencyLimiter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/ConcurrencyLimiter.swift; sourceTree = "<group>"; };
 		F2D3956FCB8E5BA0EA7B365B /* ShelvCore/Services/ArtistTopSongsRanking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/ArtistTopSongsRanking.swift; sourceTree = "<group>"; };
+		AAF091A70FDE00000000C0DE /* ShelvCore/Services/ArtistPlayOrder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/ArtistPlayOrder.swift; sourceTree = "<group>"; };
 		FFBB0EAEC930A6AA93845AF6 /* ShelvCore/Services/ArtistDiscography.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/ArtistDiscography.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -279,6 +279,7 @@
 				7032627BABC540CC8752182E /* ShelvCore/Services/PlaylistDuplicateChecker.swift */,
 				FFBB0EAEC930A6AA93845AF6 /* ShelvCore/Services/ArtistDiscography.swift */,
 				F2D3956FCB8E5BA0EA7B365B /* ShelvCore/Services/ArtistTopSongsRanking.swift */,
+				AAF091A70FDE00000000C0DE /* ShelvCore/Services/ArtistPlayOrder.swift */,
 				DB776033CC96417A93CA66DB /* ShelvCore/Services/ConcurrencyLimiter.swift */,
 				BC10012D2FFE000000000001 /* ShelvCore/Models/DownloadModels.swift */,
 				BC10013D2FFE000000000001 /* ShelvCore/Models/ShortcutPlaybackModels.swift */,
@@ -314,7 +315,6 @@
 				BC1001512FFE000000000001 /* ShelvCore/Services/SubsonicResponseCompatibility.swift */,
 				BC1001532FFE000000000001 /* ShelvCore/Stores/SearchHistoryStore.swift */,
 				BC1001552FFE000000000001 /* ShelvCore/Support/AlphabetIndexSelection.swift */,
-				AAF091A70FDE00000000C0DE /* ShelvCore/Services/ArtistPlayOrder.swift */,
 				BC10014D2FFE000000000001 /* ShelvCore/Stores/DownloadUIStateHub.swift */,
 			);
 			name = "ShelvCore Test Sources";
@@ -631,6 +631,7 @@
 				767C48F98385493A929D3CF5 /* ShelvCore/Services/PlaylistDuplicateChecker.swift in Sources */,
 				A3BC3F4796D89CE06D73AEBA /* ShelvCore/Services/ArtistDiscography.swift in Sources */,
 				4C9CE80450C542811BFC06B9 /* ShelvCore/Services/ArtistTopSongsRanking.swift in Sources */,
+				BBF091A70FDE00000000C0DE /* ShelvCore/Services/ArtistPlayOrder.swift in Sources */,
 				D65A40B16B924F709F912515 /* ShelvCore/Services/ConcurrencyLimiter.swift in Sources */,
 				BC10012C2FFE000000000001 /* ShelvCore/Models/DownloadModels.swift in Sources */,
 				BC10013C2FFE000000000001 /* ShelvCore/Models/ShortcutPlaybackModels.swift in Sources */,
@@ -666,7 +667,6 @@
 				BC1001502FFE000000000001 /* ShelvCore/Services/SubsonicResponseCompatibility.swift in Sources */,
 				BC1001522FFE000000000001 /* ShelvCore/Stores/SearchHistoryStore.swift in Sources */,
 				BC1001542FFE000000000001 /* ShelvCore/Support/AlphabetIndexSelection.swift in Sources */,
-				BBF091A70FDE00000000C0DE /* ShelvCore/Services/ArtistPlayOrder.swift in Sources */,
 				BC10014C2FFE000000000001 /* ShelvCore/Stores/DownloadUIStateHub.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Shelv/Views/Library/ArtistDetailView.swift
+++ b/Shelv/Views/Library/ArtistDetailView.swift
@@ -285,7 +285,8 @@ struct ArtistDetailView: View {
             Task {
                 let songs = await fetchAllSongs(from: albums)
                 guard !songs.isEmpty else { return }
-                player.play(songs: songs, startIndex: 0)
+                let ordered = ArtistPlayOrder.songs(topSongs: topSongs, discography: songs)
+                player.play(songs: ordered, startIndex: 0)
             }
         } label: {
             Label(String(localized: "play"), systemImage: "play.fill")

--- a/ShelvCore/Services/ArtistPlayOrder.swift
+++ b/ShelvCore/Services/ArtistPlayOrder.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// What the Play button on an artist page should queue.
+///
+/// Playing the discography in album order sounds arbitrary on a library made of
+/// fragments: a listener who owns three tracks of an album gets them before the
+/// artist's best known song. Leading with the top songs fixes the order without
+/// letting the queue run dry after ten tracks.
+nonisolated enum ArtistPlayOrder {
+    /// Top songs in their ranked order, then everything else in discography
+    /// order. A song appears once, at its earliest position.
+    static func songs(topSongs: [Song], discography: [Song]) -> [Song] {
+        guard !topSongs.isEmpty else { return discography }
+
+        var seen = Set<String>()
+        var ordered: [Song] = []
+        ordered.reserveCapacity(topSongs.count + discography.count)
+
+        for song in topSongs + discography where seen.insert(song.id).inserted {
+            ordered.append(song)
+        }
+        return ordered
+    }
+}

--- a/ShelvTests/ArtistPlayOrderTests.swift
+++ b/ShelvTests/ArtistPlayOrderTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+
+final class ArtistPlayOrderTests: XCTestCase {
+    private func song(_ id: String) -> Song { Song(id: id, title: "Track \(id)") }
+
+    func testWithoutTopSongsTheDiscographyIsUntouched() {
+        let discography = [song("1"), song("2"), song("3")]
+
+        let ordered = ArtistPlayOrder.songs(topSongs: [], discography: discography)
+
+        XCTAssertEqual(ordered.map(\.id), ["1", "2", "3"])
+    }
+
+    func testTopSongsLeadInTheirRankedOrder() {
+        let ordered = ArtistPlayOrder.songs(
+            topSongs: [song("3"), song("1")],
+            discography: [song("1"), song("2"), song("3"), song("4")]
+        )
+
+        XCTAssertEqual(ordered.map(\.id), ["3", "1", "2", "4"])
+    }
+
+    func testASongNeverPlaysTwice() {
+        let ordered = ArtistPlayOrder.songs(
+            topSongs: [song("2"), song("2")],
+            discography: [song("1"), song("2")]
+        )
+
+        XCTAssertEqual(ordered.map(\.id), ["2", "1"])
+    }
+
+    func testATopSongMissingFromTheDiscographyStillPlays() {
+        // getTopSongs can name a track the artist page did not load, for
+        // instance when the album list is still coming in.
+        let ordered = ArtistPlayOrder.songs(
+            topSongs: [song("99")],
+            discography: [song("1")]
+        )
+
+        XCTAssertEqual(ordered.map(\.id), ["99", "1"])
+    }
+
+    func testAnEmptyDiscographyLeavesTheTopSongs() {
+        let ordered = ArtistPlayOrder.songs(topSongs: [song("1")], discography: [])
+
+        XCTAssertEqual(ordered.map(\.id), ["1"])
+    }
+}


### PR DESCRIPTION
The Play button queues every track of every album in discography order. On a complete library that is defensible. On a library made of fragments it is not: my server has 3122 albums, 80 % of them holding a single track, so Play opens with whichever fragment sorts first and the artist's best known song may never come up.

The page already knows better. `getTopSongs` is loaded for the Top Songs section right above the button, and ignored when the button is pressed.

## What this does

Play queues the top songs first, in ranked order, then the rest of the discography. Nothing is dropped and there are no duplicates.

- Shuffle is untouched. It discards order by definition.
- An artist with no top songs keeps exactly the current behaviour.
- On macOS the 200-track cap now trims from the end instead of sampling at random, so the top songs survive it. The shuffle path still samples.

Ordering lives in `ShelvCore/Services/ArtistPlayOrder.swift`, pure and covered by 5 tests, next to `ArtistTopSongsRanking`.

+20 / -4 across iOS, macOS and tvOS.

## Question

Would you rather Play queued only the top songs? That is a one-line change, but it leaves the queue empty after ten or so tracks, which felt worse in use.

## Verification

459 iOS tests pass, 5 of them new. macOS builds. tvOS builds too, against the tvOS 26.5 simulator — but only on top of #46, which fixes a `@ViewBuilder` on a `Bool` that stops the whole tvOS target compiling on current `main`.
