### PR TITLE
fix: make the request-coalescing test stop racing itself

### DIFF
--- a/ShelvTests/SubsonicResponseCompatibilityTests.swift
+++ b/ShelvTests/SubsonicResponseCompatibilityTests.swift
@@ -194,11 +194,21 @@ final class SubsonicResponseCompatibilityTests: XCTestCase {
         let gate = SubsonicResponseRequestGate()
         let counter = AsyncCounter()
 
+        let firstStarted = AsyncSignal()
+
         async let first = gate.data(for: "server|getAlbumList2|xml") {
             await counter.increment()
+            await firstStarted.signal()
             try await Task.sleep(for: .milliseconds(50))
             return Data("xml".utf8)
         }
+
+        // `async let` does not promise to start its children in source order.
+        // Without waiting here the two calls race for the gate, and when the
+        // second one wins it becomes the request everybody waits on, so both
+        // get "other". Measured on an unmodified tree: 2 failures in 10 runs.
+        await firstStarted.wait()
+
         async let second = gate.data(for: "server|getAlbumList2|xml") {
             await counter.increment()
             return Data("other".utf8)
@@ -513,5 +523,25 @@ private actor AsyncCounter {
 
     func increment() {
         value += 1
+    }
+}
+
+/// Lets a test wait until an operation has really started, rather than assume
+/// the order in which `async let` happens to start its children.
+private actor AsyncSignal {
+    private var hasFired = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func signal() {
+        guard !hasFired else { return }
+        hasFired = true
+        let pending = waiters
+        waiters.removeAll()
+        pending.forEach { $0.resume() }
+    }
+
+    func wait() async {
+        guard !hasFired else { return }
+        await withCheckedContinuation { waiters.append($0) }
     }
 }


### PR DESCRIPTION
`SubsonicResponseCompatibilityTests.testIdenticalFallbackRequestsAreCoalesced()` fails at random on `main`.

I ran it 15 times on a detached `origin/main` at 6b5ea29, with no changes at all: **2 failures out of 10** in the first pass. It is frequent enough that any PR can look red for reasons that have nothing to do with it — it cost me three CI-equivalent runs while working on other branches.

## Why it races

The test fires both requests with `async let` and assumes the first one reaches the gate first:

```swift
async let first  = gate.data(for: key) { ...sleep 50ms...; return Data("xml") }
async let second = gate.data(for: key) { return Data("other") }
```

`async let` does not promise to start its children in source order. When the second one enters the actor first it becomes the in-flight request everybody waits on, so both callers get `"other"` and `XCTAssertEqual(values, ["xml", "xml"])` fails.

The gate itself is fine. `SubsonicResponseRequestGate` is an actor and registers the in-flight entry before its first suspension point, so a later caller always sees it. Only the test's assumption about ordering is wrong.

## The fix

The first request signals once it is actually running, and the test waits for that signal before starting the second. That is the situation the gate exists for — a request arriving while an identical one is in flight — and it now happens deterministically.

Adds a small `AsyncSignal` actor next to the existing `AsyncCounter`.

## Verification

15 consecutive runs of the whole `SubsonicResponseCompatibilityTests` class, **0 failures**, against 2 in 10 before.
