### PR TITLE
fix: make the tvOS target build again

### DIFF
--- a/Shelv TV/Views/Library/LibraryView.swift
+++ b/Shelv TV/Views/Library/LibraryView.swift
@@ -485,7 +485,6 @@ struct LibraryView: View {
 
     // MARK: - Favoriten
 
-    @ViewBuilder
     private var hasNoFavoritePlayback: Bool {
         store.favoriteAlbums.isEmpty && store.favoriteSongs.isEmpty
     }


### PR DESCRIPTION
The tvOS target does not compile on `main`.

```
Shelv TV/Views/Library/LibraryView.swift:490:9: error: static method
'buildExpression' requires that 'Bool' conform to 'View'
```

`17bfbc8` ("add a shuffle button and a filter to the favorites overview") gave `hasNoFavoritePlayback` a `@ViewBuilder` attribute while porting the button to tvOS, but the property returns `Bool`. `@ViewBuilder` then tries to treat that boolean as a view and the whole target stops building.

The macOS twin in `Shelv Mac/Views/FavoritesView.swift:127` declares the same property without the attribute, which is the shape this one wants. Removing the line is the whole fix.

## How I found it, and why it may have been missed

The tvOS platform is a separate 3.76 GB download and is not installed with Xcode by default — `xcodebuild -showsdks` still lists a tvOS SDK, which makes it look available, but every tvOS destination is rejected with "tvOS 26.5 is not installed". I spent most of a session unable to compile the target for exactly that reason and only caught this after installing it.

## Verification

Built `Shelv TV` against the tvOS 26.5 simulator (Apple TV 4K, 3rd generation):

- On `main`: **exit 65**, one error, the one above.
- With this one-line change: **BUILD SUCCEEDED**, zero errors.

I also built every branch I currently have open against tvOS. All eight produced that same single error and nothing else, so nothing else is broken behind it.
