### PR TITLE
fix: say when the artist page fell back to downloads

### DIFF
--- a/Shelv Mac/Views/ArtistDetailView.swift
+++ b/Shelv Mac/Views/ArtistDetailView.swift
@@ -243,6 +243,17 @@ struct ArtistDetailView: View {
                                 .padding(.horizontal, 20)
                             }
 
+                            if vm.isShowingDownloadsOnly, !offlineMode.isOffline {
+                                Label(
+                                    String(localized: "showing_downloads_only"),
+                                    systemImage: "wifi.exclamationmark"
+                                )
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(.horizontal, 20)
+                            }
+
                             if isGrid && searchQuery.isEmpty {
                                 VStack(alignment: .leading, spacing: 24) {
                                     if !albumsOnly.isEmpty {
@@ -765,6 +776,10 @@ class ArtistDetailViewModel: ObservableObject {
     @Published var isLoading: Bool = false
     @Published var isLoadingSongs: Bool = false
     @Published var errorMessage: String?
+    /// True while the page shows only what is downloaded on this Mac, because
+    /// the server could not be reached. Without saying so, a failed
+    /// `getArtist` looks like a small but complete discography.
+    @Published var isShowingDownloadsOnly = false
 
     private let api = SubsonicAPIService.shared
     private let maxSongs = 200
@@ -809,6 +824,7 @@ class ArtistDetailViewModel: ObservableObject {
             }
 
             artist = detail
+            isShowingDownloadsOnly = false
             albums = (detail.album ?? []).sorted { ($0.year ?? 0) > ($1.year ?? 0) }
             topSongs = loadedTopSongs
             biography = info?.biography?.strippingHTML
@@ -835,6 +851,7 @@ class ArtistDetailViewModel: ObservableObject {
                               coverArt: local.coverArtId,
                               album: albumsAsModel)
         albums = albumsAsModel
+        isShowingDownloadsOnly = true
     }
 
     func fetchSongs(albums: [Album]) async -> [Song] {

--- a/Shelv Mac/de.lproj/Localizable.strings
+++ b/Shelv Mac/de.lproj/Localizable.strings
@@ -158,6 +158,7 @@
 "discography" = "Diskografie";
 "release_group_all" = "Alle";
 "release_group_singles_eps" = "Singles & EPs";
+"showing_downloads_only" = "Server nicht erreichbar. Es werden nur deine Downloads angezeigt.";
 "fans_also_like" = "Ähnliche Künstler";
 "more_info" = "Mehr Infos";
 "show_more" = "Mehr anzeigen";

--- a/Shelv Mac/en.lproj/Localizable.strings
+++ b/Shelv Mac/en.lproj/Localizable.strings
@@ -158,6 +158,7 @@
 "discography" = "Discography";
 "release_group_all" = "All";
 "release_group_singles_eps" = "Singles & EPs";
+"showing_downloads_only" = "Server unreachable. Showing your downloads only.";
 "fans_also_like" = "Similar Artists";
 "more_info" = "More Info";
 "show_more" = "Show more";

--- a/Shelv Mac/fr.lproj/Localizable.strings
+++ b/Shelv Mac/fr.lproj/Localizable.strings
@@ -458,6 +458,7 @@
 "discography" = "Discographie";
 "release_group_all" = "Tout";
 "release_group_singles_eps" = "Singles et EP";
+"showing_downloads_only" = "Serveur injoignable. Seuls vos téléchargements sont affichés.";
 "fans_also_like" = "Artistes similaires";
 "more_info" = "Plus d’informations";
 "show_more" = "Afficher plus";

--- a/Shelv Mac/zh-Hans.lproj/Localizable.strings
+++ b/Shelv Mac/zh-Hans.lproj/Localizable.strings
@@ -158,6 +158,7 @@
 "discography" = "作品";
 "release_group_all" = "全部";
 "release_group_singles_eps" = "单曲和 EP";
+"showing_downloads_only" = "无法连接服务器，仅显示已下载的内容。";
 "fans_also_like" = "相似艺人";
 "more_info" = "更多信息";
 "show_more" = "显示更多";

--- a/Shelv/Views/Library/ArtistDetailView.swift
+++ b/Shelv/Views/Library/ArtistDetailView.swift
@@ -25,6 +25,10 @@ struct ArtistDetailView: View {
     @State private var biography: String?
     @State private var isLoading = true
     @State private var errorMessage: String?
+    /// True while the page shows only what is downloaded on this device,
+    /// because the server could not be reached. Without saying so, a failed
+    /// `getArtist` looks like a small but complete discography.
+    @State private var isShowingDownloadsOnly = false
     @State private var showError = false
     @State private var currentToast: ShelveToast?
     @State private var searchQuery = ""
@@ -102,6 +106,21 @@ struct ArtistDetailView: View {
 
     private var shortReleases: [Album] {
         ArtistDiscography.filter(sortedAlbums, to: .singlesAndEPs)
+    }
+
+    /// Says out loud that the page fell back to the device's downloads.
+    @ViewBuilder
+    private var downloadsOnlyNotice: some View {
+        if isShowingDownloadsOnly, !offlineMode.isOffline {
+            Section {
+                Label(String(localized: "showing_downloads_only"), systemImage: "wifi.exclamationmark")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .listRowBackground(Color.clear)
+                    .listRowSeparator(.hidden)
+            }
+        }
     }
 
     /// Newest by release year, then by the date the server first saw it.
@@ -421,6 +440,8 @@ struct ArtistDetailView: View {
                         .listRowSeparator(.hidden)
                 }
             } else {
+                downloadsOnlyNotice
+
                 if let latestRelease {
                     Section {
                         ArtistLatestReleaseCard(album: latestRelease, accentColor: accentColor)
@@ -548,6 +569,8 @@ struct ArtistDetailView: View {
                         .listRowSeparator(.hidden)
                 }
             } else if !filteredAlbums.isEmpty {
+                downloadsOnlyNotice
+
                 Section {
                     if !releaseGroups.isEmpty {
                         ArtistReleaseGroupPicker(selection: $releaseGroup, groups: releaseGroups)
@@ -897,6 +920,7 @@ struct ArtistDetailView: View {
             }
 
             detail = loadedDetail
+            isShowingDownloadsOnly = false
             topSongs = loadedTopSongs
             biography = info?.biography?.strippingHTML
             // Servers can list a track/featured artist with no album of their
@@ -932,6 +956,7 @@ struct ArtistDetailView: View {
             coverArt: local.coverArtId,
             album: albumsAsModel
         )
+        isShowingDownloadsOnly = true
     }
 
     private func fetchAllSongs(from albums: [Album]) async -> [Song] {

--- a/Shelv/de.lproj/Localizable.strings
+++ b/Shelv/de.lproj/Localizable.strings
@@ -36,6 +36,7 @@
 "discography" = "Diskografie";
 "release_group_all" = "Alle";
 "release_group_singles_eps" = "Singles & EPs";
+"showing_downloads_only" = "Server nicht erreichbar. Es werden nur deine Downloads angezeigt.";
 "fans_also_like" = "Ähnliche Künstler";
 "more_actions" = "Weitere Aktionen";
 "more_info" = "Mehr Infos";

--- a/Shelv/en.lproj/Localizable.strings
+++ b/Shelv/en.lproj/Localizable.strings
@@ -36,6 +36,7 @@
 "discography" = "Discography";
 "release_group_all" = "All";
 "release_group_singles_eps" = "Singles & EPs";
+"showing_downloads_only" = "Server unreachable. Showing your downloads only.";
 "fans_also_like" = "Similar Artists";
 "more_actions" = "More Actions";
 "more_info" = "More Info";

--- a/Shelv/fr.lproj/Localizable.strings
+++ b/Shelv/fr.lproj/Localizable.strings
@@ -36,6 +36,7 @@
 "discography" = "Discographie";
 "release_group_all" = "Tout";
 "release_group_singles_eps" = "Singles et EP";
+"showing_downloads_only" = "Serveur injoignable. Seuls vos téléchargements sont affichés.";
 "fans_also_like" = "Artistes similaires";
 "more_actions" = "Plus d’actions";
 "more_info" = "Plus d’informations";

--- a/Shelv/zh-Hans.lproj/Localizable.strings
+++ b/Shelv/zh-Hans.lproj/Localizable.strings
@@ -36,6 +36,7 @@
 "discography" = "作品";
 "release_group_all" = "全部";
 "release_group_singles_eps" = "单曲和 EP";
+"showing_downloads_only" = "无法连接服务器，仅显示已下载的内容。";
 "fans_also_like" = "相似艺人";
 "more_actions" = "更多操作";
 "more_info" = "更多信息";


### PR DESCRIPTION
Split out of #40 at your request. Based on `main` and independent of it: the two branches merge cleanly with each other, so either order works.

## The problem

`loadDetail()` fills the artist page from what is downloaded on the device when `getArtist` fails, and raises the error only when there is nothing at all left to show. Against a server that is down, slow, or behind a tunnel that dropped, the page comes up looking like a small but complete discography.

That is worse than an empty page. An empty page tells the listener something went wrong. A short album list does not, and nothing on screen says the rest exists.

## The change

`isShowingDownloadsOnly`, set where the local fallback runs and cleared on a successful load, on the iOS view and the macOS view model. A footnote above the discography while it is true.

Offline mode is left out of it. Showing downloads is the whole point there, so the notice would state the obvious, hence the `!offlineMode.isOffline` guard.

One key, `showing_downloads_only`, four languages, both targets. German uses `du` and French `vous`, matching `you_are_offline` in each. The wording is yours to set: you said it deserved its own pass, so here it is on its own, easy to reword or drop without touching the rest.

## Verification

`Shelv` and `Shelv Mac` both build and the suite is green on both: 464 tests on iOS 26.5 (iPhone 17 Pro), 466 on macOS, no failures. No new tests here. The change is a flag and a label, and the path it reports needs a server that refuses to answer.
