### PR TITLE
feat: stream the original at home without asking for a location

### DIFF
--- a/Shelv Mac/Views/TranscodingPanel.swift
+++ b/Shelv Mac/Views/TranscodingPanel.swift
@@ -6,6 +6,8 @@ struct TranscodingPanel: View {
     @AppStorage("transcodingWifiBitrate") private var wifiBitrate: Int = 256
     @AppStorage("transcodingCellularCodec") private var cellularCodecRaw: String = "raw"
     @AppStorage("transcodingCellularBitrate") private var cellularBitrate: Int = 128
+    @AppStorage("transcodingPrimaryURLExempt") private var primaryURLExempt = false
+    @ObservedObject private var serverStore = ServerStore.shared
     @Environment(\.themeColor) private var themeColor
 
     var body: some View {
@@ -30,6 +32,21 @@ struct TranscodingPanel: View {
                            codecBinding: $wifiCodecRaw,
                            bitrateBinding: $wifiBitrate,
                            options: TranscodingCodec.streamingOptions)
+
+                // Only shown for a server that has both URLs: with a single URL
+                // the toggle would just mean "never transcode on Wi-Fi", which
+                // the Wi-Fi profile already says.
+                if serverStore.activeServer?.hasSecondaryURL == true {
+                    Section {
+                        Toggle(String(localized: "transcoding_primary_url_exempt"), isOn: $primaryURLExempt)
+                            .tint(themeColor)
+                    } footer: {
+                        Text(String(localized: "transcoding_primary_url_exempt_footer"))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
                 subsection(title: String(localized: "data_saver"),
                            codecBinding: $cellularCodecRaw,
                            bitrateBinding: $cellularBitrate,

--- a/Shelv Mac/de.lproj/Localizable.strings
+++ b/Shelv Mac/de.lproj/Localizable.strings
@@ -219,6 +219,8 @@
 "gapless" = "Gapless";
 "scrobble" = "Scrobble";
 "transcoding" = "Transcoding";
+"transcoding_primary_url_exempt" = "Original über primäre URL";
+"transcoding_primary_url_exempt_footer" = "Erreicht Shelv den Server über seine primäre URL, wird die Originaldatei gestreamt und das WLAN-Profil ignoriert. Unterwegs auf die sekundäre URL wechseln.";
 "no_track" = "Kein Titel";
 "shuffle_off" = "Zufallsmodus aus";
 "shuffle_on" = "Zufallsmodus an";

--- a/Shelv Mac/en.lproj/Localizable.strings
+++ b/Shelv Mac/en.lproj/Localizable.strings
@@ -219,6 +219,8 @@
 "gapless" = "Gapless";
 "scrobble" = "Scrobble";
 "transcoding" = "Transcoding";
+"transcoding_primary_url_exempt" = "Original on primary URL";
+"transcoding_primary_url_exempt_footer" = "When Shelv reaches the server through its primary URL it streams the original file and ignores the Wi-Fi profile. Switch to the secondary URL when you are away.";
 "no_track" = "No track";
 "shuffle_off" = "Shuffle off";
 "shuffle_on" = "Shuffle on";

--- a/Shelv Mac/fr.lproj/Localizable.strings
+++ b/Shelv Mac/fr.lproj/Localizable.strings
@@ -206,6 +206,8 @@
 "gapless" = "Enchaînement sans blanc";
 "scrobble" = "Scrobble";
 "transcoding" = "Transcodage";
+"transcoding_primary_url_exempt" = "Original sur l’URL principale";
+"transcoding_primary_url_exempt_footer" = "Quand Shelv joint le serveur par son URL principale, il diffuse le fichier d’origine et ignore le profil Wi-Fi. Basculez sur l’URL secondaire en déplacement.";
 "no_track" = "Aucun morceau";
 "shuffle_off" = "Aléatoire désactivé";
 "shuffle_on" = "Aléatoire activé";

--- a/Shelv Mac/zh-Hans.lproj/Localizable.strings
+++ b/Shelv Mac/zh-Hans.lproj/Localizable.strings
@@ -219,6 +219,8 @@
 "gapless" = "无缝播放";
 "scrobble" = "Scrobble";
 "transcoding" = "转码";
+"transcoding_primary_url_exempt" = "主地址使用原始文件";
+"transcoding_primary_url_exempt_footer" = "通过主地址连接服务器时，Shelv 会播放原始文件并忽略 Wi-Fi 配置。外出时请切换到备用地址。";
 "no_track" = "无曲目";
 "shuffle_off" = "随机播放：关闭";
 "shuffle_on" = "随机播放：开启";

--- a/Shelv.xcodeproj/project.pbxproj
+++ b/Shelv.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		BC1001062FFE000000000001 /* ShelvCore/Models/QueueSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1001162FFE000000000001 /* ShelvCore/Models/QueueSnapshot.swift */; };
 		BC1001072FFE000000000001 /* ShelvCore/Services/AudioPlayerQueueState.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1001172FFE000000000001 /* ShelvCore/Services/AudioPlayerQueueState.swift */; };
 		BC1001082FFE000000000001 /* ShelvCore/Services/TranscodingPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1001182FFE000000000001 /* ShelvCore/Services/TranscodingPolicy.swift */; };
+		BBF07A0DEC1D00000000C0DE /* ShelvCore/Services/TranscodingProfileDecision.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF07A0DEC1D00000000C0DE /* ShelvCore/Services/TranscodingProfileDecision.swift */; };
 		BC1001092FFE000000000001 /* ShelvCore/Services/NetworkStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1001192FFE000000000001 /* ShelvCore/Services/NetworkStatus.swift */; };
 		BC10010A2FFE000000000001 /* ShelvCore/Services/URL+QueryParam.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC10011A2FFE000000000001 /* ShelvCore/Services/URL+QueryParam.swift */; };
 		BC10010B2FFE000000000001 /* ShelvCore/Utilities/PathSafe.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC10011B2FFE000000000001 /* ShelvCore/Utilities/PathSafe.swift */; };
@@ -110,6 +111,7 @@
 		BC1001162FFE000000000001 /* ShelvCore/Models/QueueSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Models/QueueSnapshot.swift; sourceTree = "<group>"; };
 		BC1001172FFE000000000001 /* ShelvCore/Services/AudioPlayerQueueState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/AudioPlayerQueueState.swift; sourceTree = "<group>"; };
 		BC1001182FFE000000000001 /* ShelvCore/Services/TranscodingPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/TranscodingPolicy.swift; sourceTree = "<group>"; };
+		AAF07A0DEC1D00000000C0DE /* ShelvCore/Services/TranscodingProfileDecision.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/TranscodingProfileDecision.swift; sourceTree = "<group>"; };
 		BC1001192FFE000000000001 /* ShelvCore/Services/NetworkStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Services/NetworkStatus.swift; sourceTree = "<group>"; };
 		BC10011A2FFE000000000001 /* ShelvCore/Services/URL+QueryParam.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShelvCore/Services/URL+QueryParam.swift"; sourceTree = "<group>"; };
 		BC10011B2FFE000000000001 /* ShelvCore/Utilities/PathSafe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShelvCore/Utilities/PathSafe.swift; sourceTree = "<group>"; };
@@ -290,6 +292,7 @@
 				BC1001172FFE000000000001 /* ShelvCore/Services/AudioPlayerQueueState.swift */,
 				BC1001432FFE000000000001 /* ShelvCore/Services/AudioPlayerStreamCacheJob.swift */,
 				BC1001182FFE000000000001 /* ShelvCore/Services/TranscodingPolicy.swift */,
+				AAF07A0DEC1D00000000C0DE /* ShelvCore/Services/TranscodingProfileDecision.swift */,
 				BC1001192FFE000000000001 /* ShelvCore/Services/NetworkStatus.swift */,
 				BC1001292FFE000000000001 /* ShelvCore/Services/OfflineServerErrorPresentationPolicy.swift */,
 				D76D0722C024A55F5646646B /* ShelvCore/Services/RemoteStreamFailureRetryPolicy.swift */,
@@ -644,6 +647,7 @@
 				BC1001072FFE000000000001 /* ShelvCore/Services/AudioPlayerQueueState.swift in Sources */,
 				BC1001422FFE000000000001 /* ShelvCore/Services/AudioPlayerStreamCacheJob.swift in Sources */,
 				BC1001082FFE000000000001 /* ShelvCore/Services/TranscodingPolicy.swift in Sources */,
+				BBF07A0DEC1D00000000C0DE /* ShelvCore/Services/TranscodingProfileDecision.swift in Sources */,
 				BC1001092FFE000000000001 /* ShelvCore/Services/NetworkStatus.swift in Sources */,
 				BC1001282FFE000000000001 /* ShelvCore/Services/OfflineServerErrorPresentationPolicy.swift in Sources */,
 				54755D0F4F7624D1CB2AFAA0 /* ShelvCore/Services/RemoteStreamFailureRetryPolicy.swift in Sources */,

--- a/Shelv/Views/Settings/TranscodingSettingsView.swift
+++ b/Shelv/Views/Settings/TranscodingSettingsView.swift
@@ -6,6 +6,8 @@ struct TranscodingSettingsView: View {
     @AppStorage("transcodingWifiBitrate") private var wifiBitrate: Int = 256
     @AppStorage("transcodingCellularCodec") private var cellularCodecRaw: String = "raw"
     @AppStorage("transcodingCellularBitrate") private var cellularBitrate: Int = 128
+    @AppStorage("transcodingPrimaryURLExempt") private var primaryURLExempt = false
+    @ObservedObject private var serverStore = ServerStore.shared
 
     @State private var showInfo = false
 
@@ -24,6 +26,17 @@ struct TranscodingSettingsView: View {
                 bitrateBinding: $wifiBitrate,
                 options: TranscodingCodec.streamingOptions
             )
+
+            // Only shown for a server that has both URLs: with a single URL the
+            // toggle would just mean "never transcode on Wi-Fi", which the
+            // Wi-Fi profile already says.
+            if serverStore.activeServer?.hasSecondaryURL == true {
+                Section {
+                    Toggle(String(localized: "transcoding_primary_url_exempt"), isOn: $primaryURLExempt)
+                } footer: {
+                    Text(String(localized: "transcoding_primary_url_exempt_footer"))
+                }
+            }
 
             transcodingSection(
                 title: String(localized: "cellular"),

--- a/Shelv/de.lproj/Localizable.strings
+++ b/Shelv/de.lproj/Localizable.strings
@@ -353,6 +353,8 @@
 "track_gain" = "Track Gain";
 "album_gain" = "Album Gain";
 "transcoding" = "Transkodierung";
+"transcoding_primary_url_exempt" = "Original über primäre URL";
+"transcoding_primary_url_exempt_footer" = "Erreicht Shelv den Server über seine primäre URL, wird die Originaldatei gestreamt und das WLAN-Profil ignoriert. Unterwegs auf die sekundäre URL wechseln.";
 "gapless" = "Gapless";
 "scrobble" = "Scrobble";
 "autofetch_on_playback" = "Beim Abspielen laden";

--- a/Shelv/en.lproj/Localizable.strings
+++ b/Shelv/en.lproj/Localizable.strings
@@ -353,6 +353,8 @@
 "track_gain" = "Track Gain";
 "album_gain" = "Album Gain";
 "transcoding" = "Transcoding";
+"transcoding_primary_url_exempt" = "Original on primary URL";
+"transcoding_primary_url_exempt_footer" = "When Shelv reaches the server through its primary URL it streams the original file and ignores the Wi-Fi profile. Switch to the secondary URL when you are away.";
 "gapless" = "Gapless";
 "scrobble" = "Scrobble";
 "autofetch_on_playback" = "Auto-fetch on playback";

--- a/Shelv/fr.lproj/Localizable.strings
+++ b/Shelv/fr.lproj/Localizable.strings
@@ -353,6 +353,8 @@
 "track_gain" = "Gain du morceau";
 "album_gain" = "Gain de l’album";
 "transcoding" = "Transcodage";
+"transcoding_primary_url_exempt" = "Original sur l’URL principale";
+"transcoding_primary_url_exempt_footer" = "Quand Shelv joint le serveur par son URL principale, il diffuse le fichier d’origine et ignore le profil Wi-Fi. Basculez sur l’URL secondaire en déplacement.";
 "gapless" = "Enchaînement sans blanc";
 "scrobble" = "Scrobble";
 "autofetch_on_playback" = "Récupération auto à la lecture";

--- a/Shelv/zh-Hans.lproj/Localizable.strings
+++ b/Shelv/zh-Hans.lproj/Localizable.strings
@@ -353,6 +353,8 @@
 "track_gain" = "曲目增益";
 "album_gain" = "专辑增益";
 "transcoding" = "转码";
+"transcoding_primary_url_exempt" = "主地址使用原始文件";
+"transcoding_primary_url_exempt_footer" = "通过主地址连接服务器时，Shelv 会播放原始文件并忽略 Wi-Fi 配置。外出时请切换到备用地址。";
 "gapless" = "无缝播放";
 "scrobble" = "Scrobble";
 "autofetch_on_playback" = "播放时自动获取";

--- a/ShelvCore/Services/TranscodingPolicy.swift
+++ b/ShelvCore/Services/TranscodingPolicy.swift
@@ -31,16 +31,43 @@ nonisolated enum TranscodingBitrate: Int, CaseIterable, Identifiable {
 }
 
 nonisolated struct TranscodingPolicy {
+    /// Written by `ServerStore` whenever the active server or its URL slot
+    /// changes, so the streaming policy can tell home from away.
+    static let usingSecondaryURLKey = "activeServerUsesSecondaryURL"
+    /// Whether the active server holds a secondary URL at all. Without one
+    /// there is no away slot, so nothing to exempt.
+    static let hasSecondaryURLKey = "activeServerHasSecondaryURL"
+
     /// Liefert das gewünschte Stream-Format basierend auf aktuellem Netz.
     /// `nil` = kein Transcoding, Original wird angefordert.
     static func currentStreamFormat() -> (codec: TranscodingCodec, bitrate: Int)? {
-        guard UserDefaults.standard.bool(forKey: "transcodingEnabled") else { return nil }
-        // Data-Saver (macOS-Menü): erzwingt das Cellular-Profil auch im WLAN.
-        // Auf iOS ist der Key nie gesetzt → kein Verhaltensunterschied.
-        let dataSaver = UserDefaults.standard.bool(forKey: "dataSaverEnabled")
-        let isWifi = !dataSaver && NetworkStatus.shared.isOnWifi
-        let codecKey = isWifi ? "transcodingWifiCodec" : "transcodingCellularCodec"
-        let bitrateKey = isWifi ? "transcodingWifiBitrate" : "transcodingCellularBitrate"
+        let profile = TranscodingProfileDecision.profile(
+            isEnabled: UserDefaults.standard.bool(forKey: "transcodingEnabled"),
+            // Data-Saver (macOS-Menü): erzwingt das Cellular-Profil auch im WLAN.
+            // Auf iOS ist der Key nie gesetzt → kein Verhaltensunterschied.
+            dataSaver: UserDefaults.standard.bool(forKey: "dataSaverEnabled"),
+            isOnWifi: NetworkStatus.shared.isOnWifi,
+            // Read as a plain flag rather than through SubsonicAPIService:
+            // this file is compiled into ShelvTests, which does not include it.
+            // ServerStore keeps the key in step with the active server.
+            serverHasSecondaryURL: UserDefaults.standard.bool(forKey: TranscodingPolicy.hasSecondaryURLKey),
+            isOnPrimaryServerURL: !UserDefaults.standard.bool(forKey: TranscodingPolicy.usingSecondaryURLKey),
+            exemptsPrimaryServerURL: UserDefaults.standard.bool(forKey: "transcodingPrimaryURLExempt")
+        )
+
+        let codecKey: String
+        let bitrateKey: String
+        switch profile {
+        case .original:
+            return nil
+        case .wifi:
+            codecKey = "transcodingWifiCodec"
+            bitrateKey = "transcodingWifiBitrate"
+        case .cellular:
+            codecKey = "transcodingCellularCodec"
+            bitrateKey = "transcodingCellularBitrate"
+        }
+
         let codecRaw = UserDefaults.standard.string(forKey: codecKey) ?? "raw"
         guard let codec = TranscodingCodec(rawValue: codecRaw), codec != .raw else { return nil }
         let rate = UserDefaults.standard.integer(forKey: bitrateKey)

--- a/ShelvCore/Services/TranscodingProfileDecision.swift
+++ b/ShelvCore/Services/TranscodingProfileDecision.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// Which transcoding profile a stream should use.
+nonisolated enum TranscodingProfile: Equatable, Sendable {
+    /// Ask the server for the original file.
+    case original
+    /// The Wi-Fi profile from Settings.
+    case wifi
+    /// The cellular profile from Settings.
+    case cellular
+}
+
+/// Picking the profile, separated from reading `UserDefaults` so it can be tested.
+///
+/// A listener on a slow uplink wants the original at home and a transcode
+/// everywhere else, but the Wi-Fi profile applies to every Wi-Fi alike (#7).
+/// Rather than read the SSID, which costs a location permission on iOS, this
+/// uses something the app already knows: a server can hold a primary and a
+/// secondary URL, and the active slot is the listener saying where they are.
+nonisolated enum TranscodingProfileDecision {
+    static func profile(
+        isEnabled: Bool,
+        dataSaver: Bool,
+        isOnWifi: Bool,
+        serverHasSecondaryURL: Bool,
+        isOnPrimaryServerURL: Bool,
+        exemptsPrimaryServerURL: Bool
+    ) -> TranscodingProfile {
+        guard isEnabled else { return .original }
+
+        // Data Saver (the macOS menu item) forces the cellular profile onto
+        // Wi-Fi, and outranks the home exemption: it is an explicit request.
+        if dataSaver { return .cellular }
+
+        guard isOnWifi else { return .cellular }
+
+        // Only on Wi-Fi. Reaching the primary URL over cellular is not home.
+        //
+        // Both slots have to be filled for the exemption to mean anything. On a
+        // server with one URL it would read as "never transcode on Wi-Fi", and
+        // the toggle that sets it is not even shown there: a flag left on by
+        // another server must not quietly change how this one streams.
+        if exemptsPrimaryServerURL, serverHasSecondaryURL, isOnPrimaryServerURL {
+            return .original
+        }
+
+        return .wifi
+    }
+}

--- a/ShelvCore/Stores/ServerStore.swift
+++ b/ShelvCore/Stores/ServerStore.swift
@@ -191,6 +191,14 @@ class ServerStore: ObservableObject {
     }
 
     private func applyToAPIService(server: SubsonicServer) async {
+        UserDefaults.standard.set(
+            server.isUsingSecondaryURL,
+            forKey: TranscodingPolicy.usingSecondaryURLKey
+        )
+        UserDefaults.standard.set(
+            server.hasSecondaryURL,
+            forKey: TranscodingPolicy.hasSecondaryURLKey
+        )
         activeServerRevision &+= 1
         let revision = activeServerRevision
         if let password = credentialCache[server.id] {

--- a/ShelvTests/TranscodingProfileDecisionTests.swift
+++ b/ShelvTests/TranscodingProfileDecisionTests.swift
@@ -1,0 +1,68 @@
+import XCTest
+
+final class TranscodingProfileDecisionTests: XCTestCase {
+    private func profile(
+        isEnabled: Bool = true,
+        dataSaver: Bool = false,
+        isOnWifi: Bool = true,
+        serverHasSecondaryURL: Bool = true,
+        isOnPrimaryServerURL: Bool = true,
+        exemptsPrimaryServerURL: Bool = false
+    ) -> TranscodingProfile {
+        TranscodingProfileDecision.profile(
+            isEnabled: isEnabled,
+            dataSaver: dataSaver,
+            isOnWifi: isOnWifi,
+            serverHasSecondaryURL: serverHasSecondaryURL,
+            isOnPrimaryServerURL: isOnPrimaryServerURL,
+            exemptsPrimaryServerURL: exemptsPrimaryServerURL
+        )
+    }
+
+    func testTranscodingOffAlwaysAsksForTheOriginal() {
+        XCTAssertEqual(profile(isEnabled: false), .original)
+        XCTAssertEqual(profile(isEnabled: false, isOnWifi: false), .original)
+    }
+
+    func testWithoutTheExemptionEveryWifiUsesTheWifiProfile() {
+        XCTAssertEqual(profile(isOnPrimaryServerURL: true), .wifi)
+        XCTAssertEqual(profile(isOnPrimaryServerURL: false), .wifi)
+    }
+
+    func testTheExemptionOnlyAppliesOnThePrimaryURL() {
+        XCTAssertEqual(
+            profile(isOnPrimaryServerURL: true, exemptsPrimaryServerURL: true),
+            .original
+        )
+        // Another Wi-Fi, reached through the secondary URL: transcode as before.
+        XCTAssertEqual(
+            profile(isOnPrimaryServerURL: false, exemptsPrimaryServerURL: true),
+            .wifi
+        )
+    }
+
+    func testTheExemptionNeverAppliesOffWifi() {
+        // Reaching the primary URL over cellular, for instance through a VPN,
+        // is not being at home.
+        XCTAssertEqual(
+            profile(isOnWifi: false, isOnPrimaryServerURL: true, exemptsPrimaryServerURL: true),
+            .cellular
+        )
+    }
+
+    func testAServerWithOneURLIgnoresAStaleExemption() {
+        // The toggle is not shown for such a server, so a flag left on by
+        // another one must not change how this one streams.
+        XCTAssertEqual(
+            profile(serverHasSecondaryURL: false, exemptsPrimaryServerURL: true),
+            .wifi
+        )
+    }
+
+    func testDataSaverOutranksTheExemption() {
+        XCTAssertEqual(
+            profile(dataSaver: true, isOnPrimaryServerURL: true, exemptsPrimaryServerURL: true),
+            .cellular
+        )
+    }
+}


### PR DESCRIPTION
Addresses #7. Not closing it: @chris-cole-walker should get to say whether this is the shape they wanted.

## Why not the network name

They guessed right in the issue — getting the current SSID on iOS means asking for location authorization. That is a system permission prompt in exchange for a streaming preference, and it does nothing for macOS, where a laptop has exactly the same problem.

## What the app already knows

A `SubsonicServer` carries a primary and a secondary URL, and `activeURLSlot` says which one is live. Someone who filled both slots has already told the app where they are: the home address and the outside one. That signal is free.

With the exemption on:

| | Wi-Fi, primary URL | Wi-Fi, secondary URL | Cellular |
|---|---|---|---|
| exemption off | Wi-Fi profile | Wi-Fi profile | cellular profile |
| exemption on | **original** | Wi-Fi profile | cellular profile |

Off Wi-Fi nothing changes: reaching the primary URL through a VPN on cellular is not being at home. Data Saver still outranks everything, being an explicit request rather than an inference.

## The toggle

`TranscodingSettingsView` on iOS and `TranscodingPanel` on macOS, between the Wi-Fi and cellular sections, and only for a server that holds both URLs. With one URL it would read as "never transcode on Wi-Fi", which the Wi-Fi profile already says.

Such a server also ignores the flag outright, so an exemption left on by another server cannot quietly change how it streams. That one has a test — it is the failure mode I would expect to hit in the wild.

tvOS is left out. An Apple TV does not travel.

## Shape

The decision is pure, lives in `ShelvCore/Services/TranscodingProfileDecision.swift` and has 6 tests, following `ArtistTopSongsRanking`. `TranscodingPolicy` reads the two slots as plain `UserDefaults` flags written by `ServerStore` rather than asking `SubsonicAPIService`: that file is compiled into `ShelvTests`, which does not include the API service, and referencing it from there breaks the test target.

The four localized keys sit next to `"transcoding"` rather than at the end of the file, so this branch does not fight my other open ones over the last line. Same reasoning as the `project.pbxproj` parking commits.

## Verification

Green on all three targets: 469 tests on iOS 26.5 (iPhone 17 Pro), 472 on macOS, no failures, 6 of them new. `Shelv TV` builds. Merges cleanly on `main` and against each of my four other open branches.

Nothing exercised at runtime against a real two-URL server. I have one and can report back before you merge, if you would rather see that first.

## One thing I did not decide

The exemption is a single app-wide flag, not per server. With several servers each holding two URLs, turning it on applies to whichever is active. Per-server would mean a new field on `SubsonicServer` and a migration, and that felt like your call rather than mine.
